### PR TITLE
Fix/epilepsy

### DIFF
--- a/Assets/Scenes/Menus/Title.unity
+++ b/Assets/Scenes/Menus/Title.unity
@@ -413,7 +413,7 @@ MonoBehaviour:
     m_SelectOnDown: {fileID: 0}
     m_SelectOnLeft: {fileID: 0}
     m_SelectOnRight: {fileID: 0}
-  m_Transition: 1
+  m_Transition: 2
   m_Colors:
     m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
     m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
@@ -422,8 +422,9 @@ MonoBehaviour:
     m_ColorMultiplier: 1
     m_FadeDuration: 0.1
   m_SpriteState:
-    m_HighlightedSprite: {fileID: 0}
-    m_PressedSprite: {fileID: 0}
+    m_HighlightedSprite: {fileID: 21300000, guid: ef6da8bf7ba654488a36e5484056c2df,
+      type: 3}
+    m_PressedSprite: {fileID: 21300000, guid: 5643d80fb7f09477e8e0ff4bd0836334, type: 3}
     m_DisabledSprite: {fileID: 0}
   m_AnimationTriggers:
     m_NormalTrigger: Normal
@@ -460,15 +461,15 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 0.19}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
     m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
       Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
-  m_Type: 1
+  m_Sprite: {fileID: 21300000, guid: ef6da8bf7ba654488a36e5484056c2df, type: 3}
+  m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1
   m_FillMethod: 4
@@ -1148,9 +1149,9 @@ MonoBehaviour:
     m_ColorMultiplier: 1
     m_FadeDuration: 0.1
   m_SpriteState:
-    m_HighlightedSprite: {fileID: 21300000, guid: 007f27739d27641c9898f9ff0c700bfc,
+    m_HighlightedSprite: {fileID: 21300000, guid: a0cb1ceed79fa4bcfa9294d3c55ccc22,
       type: 3}
-    m_PressedSprite: {fileID: 21300000, guid: b13ad4cdd6757409b87b0e2076c116bb, type: 3}
+    m_PressedSprite: {fileID: 21300000, guid: b9477b99906a942faa9f52fb8713343b, type: 3}
     m_DisabledSprite: {fileID: 0}
   m_AnimationTriggers:
     m_NormalTrigger: Normal
@@ -1194,7 +1195,7 @@ MonoBehaviour:
       m_Calls: []
     m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
       Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  m_Sprite: {fileID: 21300000, guid: 007f27739d27641c9898f9ff0c700bfc, type: 3}
+  m_Sprite: {fileID: 21300000, guid: a0cb1ceed79fa4bcfa9294d3c55ccc22, type: 3}
   m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1

--- a/Assets/Scripts/DraggableBlock.cs
+++ b/Assets/Scripts/DraggableBlock.cs
@@ -19,8 +19,10 @@ public class DraggableBlock : MonoBehaviour
     [Tooltip("Reference to the DraggableObject component to interface with.")]
     DraggableObject draggableObject;
 
+    // The TileData forming the DraggableBlock.
     Block block;
 
+    // The underlying array of Tiles forming the DraggableBlock.
     Tile[,] tiles;
 
     //Copies the data of a Block into this DraggableBlock’s contained Block
@@ -134,5 +136,30 @@ public class DraggableBlock : MonoBehaviour
     public void SetDefaultPosition(Vector2 pos)
     {
         draggableObject.SetDefaultPosition(pos);
+    }
+
+    public int GetWidth()
+    {
+        return block.GetWidth();
+    }
+
+    public int GetHeight()
+    {
+        return block.GetHeight();
+    }
+
+    public bool GetIsOccupied(int row, int col)
+    {
+        return block.GetIsOccupied(row, col);
+    }
+
+    public Sprite GetSprite(int row, int col)
+    {
+        return tiles[row, col].GetSprite();
+    }
+
+    public TileData.TileType GetTileType(int row, int col)
+    {
+        return tiles[row, col].GetTileType();
     }
 }

--- a/Assets/Scripts/Grid.cs
+++ b/Assets/Scripts/Grid.cs
@@ -92,6 +92,10 @@ public class Grid : MonoBehaviour
 
         foreach (Tile t in tiles)
         {
+            // Make all of the Tiles clear.
+            t.Clear();
+            t.SetSprite(TileData.TileType.Unoccupied);
+            // Subscribe to events.
             t.Changed += Tile_Changed;
         }
 
@@ -269,7 +273,9 @@ public class Grid : MonoBehaviour
             {
                 if (block.GetIsOccupied(r, c))
                 {
-                    tiles[row + r, col + c].Fill(block.GetTileType(r, c));
+                    Tile theTile = tiles[row + r, col + c];
+                    theTile.Fill(block.GetTileType(r, c));
+
                     //Note x is col and y is row
                     //coords.Add(new Coordinate(x + c, y + r));
                 }
@@ -283,8 +289,34 @@ public class Grid : MonoBehaviour
 
         return gb;
     }
+    public GridBlock WriteBlock(int row, int col, DraggableBlock block)
+    {
+        //List<Coordinate> coords = new List<Coordinate>();
+        for (int c = 0; c < block.GetWidth(); c++)
+        {
+            for (int r = 0; r < block.GetHeight(); r++)
+            {
+                if (block.GetIsOccupied(r, c))
+                {
+                    Tile theTile = tiles[row + r, col + c];
+                    theTile.Fill(block.GetTileType(r, c));
+                    theTile.SetSpriteAbsolute(block.GetSprite(r, c));
 
-    public bool SetHighlight(int row, int col, Block block, bool on)
+                    //Note x is col and y is row
+                    //coords.Add(new Coordinate(x + c, y + r));
+                }
+            }
+        }
+        GridBlock gb = new GridBlock(row, col, block.GetBlock(), this);
+        gridBlocks.Add(gb);
+
+        //call LShapeCheck after each insertion
+        //LShapeCheck(coords);
+
+        return gb;
+    }
+
+    public bool SetHighlight(int row, int col, DraggableBlock block, bool on)
     {
         if (!on)
         {
@@ -292,9 +324,10 @@ public class Grid : MonoBehaviour
             {
                 for (int r = 0; r < GetHeight(); r++)
                 {
-                    //Unhilight all tiles
+                    //Unhighlight all tiles
                     tiles[r, c].SetNormal();
-                    tiles[r, c].SetSprite(tiles[r, c].GetTileType());
+                    //tiles[r, c].SetSprite(tiles[r, c].GetTileType());
+                    tiles[r, c].SetSpriteToTrueSprite();
                 }
             }
         }
@@ -308,7 +341,7 @@ public class Grid : MonoBehaviour
                     {
                         //If can place here then set highlight
                         tiles[row + r, col + c].SetHighlight();
-                        tiles[row + r, col + c].SetSprite(block.GetTileType(r, c));
+                        tiles[row + r, col + c].SetSprite(block.GetSprite(r, c));
                     }
                 }
             }
@@ -317,7 +350,7 @@ public class Grid : MonoBehaviour
         return on;
     }
 
-    public void AnticipatedHighlight(int row, int col, Block newBlock, bool on)
+    public void AnticipatedHighlight(int row, int col, DraggableBlock newBlock, bool on)
     {
         if (on)
         {
@@ -380,7 +413,8 @@ public class Grid : MonoBehaviour
                 {
                     //Unhilight all tiles
                     tiles[r, c].SetNormal();
-                    tiles[r, c].SetSprite(tiles[r, c].GetTileType());
+                    //tiles[r, c].SetSprite(tiles[r, c].GetTileType());
+                    tiles[r, c].SetSpriteToTrueSprite();
                 }
             }
         }

--- a/Assets/Scripts/GridBlock.cs
+++ b/Assets/Scripts/GridBlock.cs
@@ -70,6 +70,11 @@ public class GridBlock
         InitializeTile(row, col, newTile);
     }
 
+    public Sprite GetSprite(int row, int col)
+    {
+        return tiles[row, col].GetSprite();
+    }
+
     public Tile[,] GetTiles()
     {
         return tiles;

--- a/Assets/Scripts/Space.cs
+++ b/Assets/Scripts/Space.cs
@@ -69,7 +69,7 @@ public class Space : MonoBehaviour
 	public void PlaceBlock(DraggableBlock block)
 	{
         AudioController.Instance.PlaceTile();
-        grid.WriteBlock(row, col, block.GetBlock()); //We're placing this block. Apparently it's the external responsibility to make sure this will work
+        grid.WriteBlock(row, col, block); //We're placing this block. Apparently it's the external responsibility to make sure this will work
         grid.PlacedDraggableBlock(); // Notify the Grid that we just placed a DraggableBlock.
         Destroy(block.gameObject); //And now we're done with this GameObject - it's on the grid
     }
@@ -81,9 +81,14 @@ public class Space : MonoBehaviour
 
     private void SnapLocation_Highlight(GameObject snapper, bool on)
     {
-        if (grid.SetHighlight(row, col, snapper.GetComponent<DraggableBlock>().GetBlock(), on))
-            grid.AnticipatedHighlight(row, col, snapper.GetComponent<DraggableBlock>().GetBlock(), true);
+        DraggableBlock draggable = snapper.GetComponent<DraggableBlock>();
+        if (grid.SetHighlight(row, col, draggable, on))
+        {
+            grid.AnticipatedHighlight(row, col, draggable, true);
+        }
         else
-            grid.AnticipatedHighlight(row, col, snapper.GetComponent<DraggableBlock>().GetBlock(), false);
+        {
+            grid.AnticipatedHighlight(row, col, draggable, false);
+        }
     }
 }

--- a/Assets/Scripts/Tile.cs
+++ b/Assets/Scripts/Tile.cs
@@ -10,10 +10,6 @@ public class Tile : MonoBehaviour
     public delegate void ChangedHandler(TileData.TileType type);
     public event ChangedHandler Changed;
 
-    //static Dictionary<TileData.TileType, Sprite> sprites = new Dictionary<TileData.TileType, Sprite>();
-
-	TileData data = new TileData();
-
     [SerializeField]
     [Tooltip("Reference to the Image component to use for rendering the Tile.")]
     Image spriteRenderer;
@@ -26,9 +22,21 @@ public class Tile : MonoBehaviour
     [SerializeField]
     [Tooltip("The fading tile prefab to instantiate.")]
     Transform fadingTilePrefab;
-	[SerializeField]
-	[Tooltip("The sprite of regular Tile.")]
-	Sprite[] tiles;
+    [SerializeField]
+    [Tooltip("The sprite of regular Tile.")]
+    Sprite[] tiles;
+    [SerializeField]
+    [Tooltip("The current Sprite of the Tile chosen in Fill. Does not necessarily match the current SpriteRenderer sprite.")]
+    Sprite trueSprite;
+
+    // The underlying TileData.
+    TileData data = new TileData();
+
+    private void Awake()
+    {
+        SetSprite(data.GetTileType());
+        trueSprite = spriteRenderer.sprite;
+    }
 
     public bool GetIsOccupied()
     {
@@ -51,14 +59,17 @@ public class Tile : MonoBehaviour
             }
 
             data.Fill(newType);
+
             SetSprite(newType);
+            trueSprite = spriteRenderer.sprite;
+
             OnChanged(newType);
         }
     }
 
     public TileData.TileType GetTileType()
     {
-		return data.GetTileType();
+        return data.GetTileType();
     }
 
     public void Clear()
@@ -92,24 +103,42 @@ public class Tile : MonoBehaviour
     public void SetSprite(TileData.TileType newType)
     {
         // Set the sprite based on the given tile type.
+        Sprite newSprite = null;
         switch (newType)
         {
             case TileData.TileType.Unoccupied:
-                spriteRenderer.sprite = spriteUnoccupied;
+                newSprite = spriteUnoccupied;
                 break;
-			case TileData.TileType.Regular:
-			int randomInt = Random.Range (0, tiles.Length);				
-				spriteRenderer.sprite = tiles[randomInt];
+            case TileData.TileType.Regular:
+                int randomInt = Random.Range(0, tiles.Length);
+                newSprite = tiles[randomInt];
                 break;
-                /*
+            /*
             case TileData.TileType.Vacant:
-                spriteRenderer.sprite = spriteVacant;
+                newSprite = spriteVacant;
                 break;
-                */
+            */
             case TileData.TileType.Vestige:
-                spriteRenderer.sprite = spriteVestige;
+                newSprite = spriteVestige;
                 break;
         }
+        spriteRenderer.sprite = newSprite;
+    }
+
+    public void SetSprite(Sprite newSprite)
+    {
+        spriteRenderer.sprite = newSprite;
+    }
+
+    public void SetSpriteToTrueSprite()
+    {
+        spriteRenderer.sprite = trueSprite;
+    }
+
+    public void SetSpriteAbsolute(Sprite newSprite)
+    {
+        spriteRenderer.sprite = newSprite;
+        trueSprite = newSprite;
     }
 
     public void EnableSpriteRenderer(bool enable)
@@ -143,6 +172,10 @@ public class Tile : MonoBehaviour
             spriteRenderer.color = new Color(255f, 0f, 0f, 1f);
     }
 
+    public Sprite GetSprite()
+    {
+        return spriteRenderer.sprite;
+    }
 
     void OnChanged(TileData.TileType newType)
     {


### PR DESCRIPTION
- Fixed epileptic flashing blocks.
- The Sprites placed on the Grid now match the Sprites of the DraggableBlocks.
- Now Grid.SetHighlight and Grid.AnticipatedHighlight both take a DraggableBlock instead of a Block as an argument. This provides these methods with a bit more information.
- Added some convenient new interface functions to DraggableBlock that helps read the underlying Block data.
- New overload for Grid.WriteBlock that takes DraggableBlock as argument and copies the DraggableBlock's Sprites to the Grid.