### PR TITLE
Fixed a bug in the calculation of the block snap offset

### DIFF
--- a/Assets/Prefabs/Space.prefab
+++ b/Assets/Prefabs/Space.prefab
@@ -64,7 +64,7 @@ MonoBehaviour:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1842248367832416}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
   m_Name: 

--- a/Assets/Prefabs/Space.prefab
+++ b/Assets/Prefabs/Space.prefab
@@ -22,6 +22,7 @@ GameObject:
   - component: {fileID: 114810337044490816}
   - component: {fileID: 114053431234703086}
   - component: {fileID: 222153896835673646}
+  - component: {fileID: 114819385993721810}
   m_Layer: 0
   m_Name: Space
   m_TagString: Untagged
@@ -57,6 +58,33 @@ MonoBehaviour:
   height: 0
   grid: {fileID: 0}
   snapLocation: {fileID: 114053431234703086}
+--- !u!114 &114819385993721810
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1842248367832416}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Sprite: {fileID: 21300000, guid: 62777f8da57f79a42b91c3691b4725a1, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
 --- !u!222 &222153896835673646
 CanvasRenderer:
   m_ObjectHideFlags: 1

--- a/Assets/Scenes/Development/paul-devline.unity
+++ b/Assets/Scenes/Development/paul-devline.unity
@@ -108,6 +108,163 @@ NavMeshSettings:
     tileSize: 256
     accuratePlacement: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1 &167463945
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 167463949}
+  - component: {fileID: 167463948}
+  - component: {fileID: 167463947}
+  - component: {fileID: 167463946}
+  m_Layer: 5
+  m_Name: Canvas
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &167463946
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 167463945}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 1301386320, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!114 &167463947
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 167463945}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 1980459831, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 0
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 800, y: 600}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+--- !u!223 &167463948
+Canvas:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 167463945}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 0
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_AdditionalShaderChannelsFlag: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+--- !u!224 &167463949
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 167463945}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0, y: 0, z: 0}
+  m_Children:
+  - {fileID: 1843931470}
+  - {fileID: 1757359659}
+  m_Father: {fileID: 0}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0, y: 0}
+--- !u!1 &395957715
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 395957718}
+  - component: {fileID: 395957717}
+  - component: {fileID: 395957716}
+  m_Layer: 0
+  m_Name: EventSystem
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &395957716
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 395957715}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 1077351063, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_HorizontalAxis: Horizontal
+  m_VerticalAxis: Vertical
+  m_SubmitButton: Submit
+  m_CancelButton: Cancel
+  m_InputActionsPerSecond: 10
+  m_RepeatDelay: 0.5
+  m_ForceModuleActive: 0
+--- !u!114 &395957717
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 395957715}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -619905303, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_FirstSelected: {fileID: 0}
+  m_sendNavigationEvents: 1
+  m_DragThreshold: 5
+--- !u!4 &395957718
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 395957715}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1565360500
 GameObject:
   m_ObjectHideFlags: 0
@@ -197,3 +354,219 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1757359658
+Prefab:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 167463949}
+    m_Modifications:
+    - target: {fileID: 224965267752668918, guid: f21d4bcd0075aa74a82be9396f44f756,
+        type: 2}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224965267752668918, guid: f21d4bcd0075aa74a82be9396f44f756,
+        type: 2}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224965267752668918, guid: f21d4bcd0075aa74a82be9396f44f756,
+        type: 2}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224965267752668918, guid: f21d4bcd0075aa74a82be9396f44f756,
+        type: 2}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224965267752668918, guid: f21d4bcd0075aa74a82be9396f44f756,
+        type: 2}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224965267752668918, guid: f21d4bcd0075aa74a82be9396f44f756,
+        type: 2}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224965267752668918, guid: f21d4bcd0075aa74a82be9396f44f756,
+        type: 2}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 224965267752668918, guid: f21d4bcd0075aa74a82be9396f44f756,
+        type: 2}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 224965267752668918, guid: f21d4bcd0075aa74a82be9396f44f756,
+        type: 2}
+      propertyPath: m_AnchoredPosition.x
+      value: -216.2878
+      objectReference: {fileID: 0}
+    - target: {fileID: 224965267752668918, guid: f21d4bcd0075aa74a82be9396f44f756,
+        type: 2}
+      propertyPath: m_AnchoredPosition.y
+      value: -373.3251
+      objectReference: {fileID: 0}
+    - target: {fileID: 224965267752668918, guid: f21d4bcd0075aa74a82be9396f44f756,
+        type: 2}
+      propertyPath: m_SizeDelta.x
+      value: 128
+      objectReference: {fileID: 0}
+    - target: {fileID: 224965267752668918, guid: f21d4bcd0075aa74a82be9396f44f756,
+        type: 2}
+      propertyPath: m_SizeDelta.y
+      value: 128
+      objectReference: {fileID: 0}
+    - target: {fileID: 224965267752668918, guid: f21d4bcd0075aa74a82be9396f44f756,
+        type: 2}
+      propertyPath: m_AnchorMin.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 224965267752668918, guid: f21d4bcd0075aa74a82be9396f44f756,
+        type: 2}
+      propertyPath: m_AnchorMin.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 224965267752668918, guid: f21d4bcd0075aa74a82be9396f44f756,
+        type: 2}
+      propertyPath: m_AnchorMax.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 224965267752668918, guid: f21d4bcd0075aa74a82be9396f44f756,
+        type: 2}
+      propertyPath: m_AnchorMax.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 224965267752668918, guid: f21d4bcd0075aa74a82be9396f44f756,
+        type: 2}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 224965267752668918, guid: f21d4bcd0075aa74a82be9396f44f756,
+        type: 2}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 114459027929769306, guid: f21d4bcd0075aa74a82be9396f44f756,
+        type: 2}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 6ec0cfd59f8d4ab45a95fb3c27791631,
+        type: 3}
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 100100000, guid: f21d4bcd0075aa74a82be9396f44f756, type: 2}
+  m_IsPrefabParent: 0
+--- !u!224 &1757359659 stripped
+RectTransform:
+  m_PrefabParentObject: {fileID: 224965267752668918, guid: f21d4bcd0075aa74a82be9396f44f756,
+    type: 2}
+  m_PrefabInternal: {fileID: 1757359658}
+--- !u!1001 &1843931469
+Prefab:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 167463949}
+    m_Modifications:
+    - target: {fileID: 224727099932873444, guid: aa00b6ee3116e044fa9b37ca96f65aaf,
+        type: 2}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224727099932873444, guid: aa00b6ee3116e044fa9b37ca96f65aaf,
+        type: 2}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224727099932873444, guid: aa00b6ee3116e044fa9b37ca96f65aaf,
+        type: 2}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224727099932873444, guid: aa00b6ee3116e044fa9b37ca96f65aaf,
+        type: 2}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224727099932873444, guid: aa00b6ee3116e044fa9b37ca96f65aaf,
+        type: 2}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224727099932873444, guid: aa00b6ee3116e044fa9b37ca96f65aaf,
+        type: 2}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224727099932873444, guid: aa00b6ee3116e044fa9b37ca96f65aaf,
+        type: 2}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 224727099932873444, guid: aa00b6ee3116e044fa9b37ca96f65aaf,
+        type: 2}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224727099932873444, guid: aa00b6ee3116e044fa9b37ca96f65aaf,
+        type: 2}
+      propertyPath: m_AnchoredPosition.x
+      value: -58.627533
+      objectReference: {fileID: 0}
+    - target: {fileID: 224727099932873444, guid: aa00b6ee3116e044fa9b37ca96f65aaf,
+        type: 2}
+      propertyPath: m_AnchoredPosition.y
+      value: -425.26028
+      objectReference: {fileID: 0}
+    - target: {fileID: 224727099932873444, guid: aa00b6ee3116e044fa9b37ca96f65aaf,
+        type: 2}
+      propertyPath: m_SizeDelta.x
+      value: 128
+      objectReference: {fileID: 0}
+    - target: {fileID: 224727099932873444, guid: aa00b6ee3116e044fa9b37ca96f65aaf,
+        type: 2}
+      propertyPath: m_SizeDelta.y
+      value: 128
+      objectReference: {fileID: 0}
+    - target: {fileID: 224727099932873444, guid: aa00b6ee3116e044fa9b37ca96f65aaf,
+        type: 2}
+      propertyPath: m_AnchorMin.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 224727099932873444, guid: aa00b6ee3116e044fa9b37ca96f65aaf,
+        type: 2}
+      propertyPath: m_AnchorMin.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 224727099932873444, guid: aa00b6ee3116e044fa9b37ca96f65aaf,
+        type: 2}
+      propertyPath: m_AnchorMax.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 224727099932873444, guid: aa00b6ee3116e044fa9b37ca96f65aaf,
+        type: 2}
+      propertyPath: m_AnchorMax.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 224727099932873444, guid: aa00b6ee3116e044fa9b37ca96f65aaf,
+        type: 2}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 224727099932873444, guid: aa00b6ee3116e044fa9b37ca96f65aaf,
+        type: 2}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 100100000, guid: aa00b6ee3116e044fa9b37ca96f65aaf, type: 2}
+  m_IsPrefabParent: 0
+--- !u!224 &1843931470 stripped
+RectTransform:
+  m_PrefabParentObject: {fileID: 224727099932873444, guid: aa00b6ee3116e044fa9b37ca96f65aaf,
+    type: 2}
+  m_PrefabInternal: {fileID: 1843931469}

--- a/Assets/Scripts/DraggableBlock.cs
+++ b/Assets/Scripts/DraggableBlock.cs
@@ -139,11 +139,16 @@ public class DraggableBlock : MonoBehaviour
         UpdateAvailableSpaces();
 
         // Calculate the snap detection offset based on the width and height of the block.
-        //const float sbt = TileUtil.spaceBetweenTiles;
-        float xoff = (width - 1) * 0.5f * grid.GetTileWidth();
-        float yoff = (height - 1) * 0.5f * grid.GetTileHeight();
+        float tileWidth = grid.GetTileWidth();
+        float tileHeight = grid.GetTileHeight();
+        float xoff = (width - 1) * 0.5f * tileWidth;
+        float yoff = (height - 1) * 0.5f * tileHeight;
         Vector2 offset = new Vector2(-xoff, yoff);
         draggableObject.SetSnapDetectionOffset(offset);
+
+        //Debug.Log("DraggableBlock width / height: " + width + " / " + height);
+        //Debug.Log("tileWidth / tileHeight: " + tileWidth + " / " + tileHeight);
+        //Debug.Log("DraggableBlock snapDetectionOffset: " + offset);
     }
 
     public void SetDefaultPosition(Vector2 pos)
@@ -175,4 +180,11 @@ public class DraggableBlock : MonoBehaviour
     {
         return tiles[row, col].GetTileType();
     }
+
+    /*
+    private void OnDrawGizmos()
+    {
+        Gizmos.DrawCube(transform.position, new Vector3(10.0f, 10.0f, 10.0f) * 10.0f);
+    }
+    */
 }


### PR DESCRIPTION
- Put DraggableObject's repeated code into a new method called GetClosestSnapLocation.
- Fixed a bug in the calculation of the block snap offset. Snapping to the grid should be much more accurate now, especially for the 4x1 blocks where the bug was most noticeable.