### PR TITLE
consistent block sprites

### DIFF
--- a/Assets/Scripts/Block.cs
+++ b/Assets/Scripts/Block.cs
@@ -101,6 +101,11 @@ public class Block
         return tiles[row, col];
     }
 
+    public void SetSpriteIndex(int row, int col, int spriteIndex)
+    {
+        tiles[row, col].SetSpriteIndex(spriteIndex);
+    }
+
     // Rotates the Block.
     public void Rotate(bool clockwise)
     {

--- a/Assets/Scripts/BlockSpawner.cs
+++ b/Assets/Scripts/BlockSpawner.cs
@@ -81,6 +81,7 @@ public class BlockSpawner : MonoBehaviour
             //int formation = Random.Range(0, json["blocks"].Count);
             var w = json[blocksNormal][i]["width"].AsInt;
             var h = json[blocksNormal][i]["height"].AsInt;
+            int sprite = json[blocksNormal][i]["sprite"].AsInt;
             var cell = json[blocksNormal][i]["cells"].AsArray;
             var tiers = json[blocksNormal][i]["tiers"].AsArray;
             //Debug.Log(cell.ToString());
@@ -101,6 +102,7 @@ public class BlockSpawner : MonoBehaviour
                     {
                         block.Fill(row, col, TileData.TileType.Regular);
                     }
+                    block.SetSpriteIndex(row, col, sprite);
                 }
             }
 

--- a/Assets/Scripts/Tile.cs
+++ b/Assets/Scripts/Tile.cs
@@ -117,6 +117,8 @@ public class Tile : MonoBehaviour
 
             SetVestigeLevel(level);
         }
+        int spriteIndex = other.GetSpriteIndex();
+        SetSpriteIndex(spriteIndex);
     }
     public void Duplicate(Tile other)
     {
@@ -133,8 +135,9 @@ public class Tile : MonoBehaviour
                 newSprite = spriteUnoccupied;
                 break;
             case TileData.TileType.Regular:
-                int randomInt = Random.Range(0, tiles.Length);
-                newSprite = tiles[randomInt];
+                //int randomInt = Random.Range(0, tiles.Length);
+                //newSprite = tiles[randomInt];
+                newSprite = tiles[data.GetSpriteIndex()];
                 break;
             case TileData.TileType.Vestige:
                 newSprite = spriteVestigeList[0];
@@ -233,5 +236,11 @@ public class Tile : MonoBehaviour
     public bool GetIsClearableInSquare()
     {
         return data.GetIsClearableInSquare();
+    }
+
+    public void SetSpriteIndex(int spriteIndex)
+    {
+        data.SetSpriteIndex(spriteIndex);
+        SetSprite(data.GetTileType());
     }
 }

--- a/Assets/Scripts/TileData.cs
+++ b/Assets/Scripts/TileData.cs
@@ -20,6 +20,9 @@ public class TileData
     [Tooltip("The TileType of this TileData.")]
     TileType type;
     [SerializeField]
+    [Tooltip("The index of the sprite in the relevant sprites array, if applicable.")]
+    int spriteIndex = 0;
+    [SerializeField]
     [Tooltip("The level of the vestige, if applicable. 0 for all non-vestige tiles.")]
     int vestigeLevel = 0;
 
@@ -39,6 +42,7 @@ public class TileData
     {
         type = other.type;
         vestigeLevel = other.vestigeLevel;
+        spriteIndex = other.spriteIndex;
     }
 
     public void Clear()
@@ -76,6 +80,16 @@ public class TileData
     public bool GetIsClearableInSquare()
     {
         return GetIsClearableInSquare(type);
+    }
+
+    public void SetSpriteIndex(int index)
+    {
+        spriteIndex = index;
+    }
+
+    public int GetSpriteIndex()
+    {
+        return spriteIndex;
     }
 
     // Returns true if the given TileType is clearable.


### PR DESCRIPTION
The sprites that the blocks use are now based on the "sprite" fields in PossibleBlocks.JSON. No more randomized tile sprites (as requested by Art).