### PR TITLE
Implemented the numerous nice requests that Design made today!

### DIFF
--- a/Assets/JSONs/PossibleBlocks.json
+++ b/Assets/JSONs/PossibleBlocks.json
@@ -5,7 +5,7 @@
 			"width" : 1,
 			"height" : 4,
 			"sprite" : 0,
-			"tiers" : [0,1,2,3]
+			"tiers" : [-1,0,1,2,3]
 			"cells" :
 			[1,
 			 1,
@@ -26,7 +26,7 @@
 			"width" : 2,
 			"height" : 2,
 			"sprite" : 2,
-			"tiers" : [0],
+			"tiers" : [-1,0],
 			"cells" :
 			[1, 0,
 			 1, 1]  

--- a/Assets/JSONs/Tuning.json
+++ b/Assets/JSONs/Tuning.json
@@ -11,5 +11,7 @@
 	"energy per cell cleared" : 1,
 	"max energy in meter" : 60,
 	"energy level animation" : [10, 40, 100],
-	"asteroids can spawn in filled cells" : false
+	"asteroids can spawn in filled cells" : false,
+	"contamination blocks alternate" : true,
+	"friendly bag max score" : 0
 }

--- a/Assets/Prefabs/BlockSpawner.prefab
+++ b/Assets/Prefabs/BlockSpawner.prefab
@@ -107,9 +107,15 @@ MonoBehaviour:
   - {fileID: 1343179390919268}
   gameFlow: {fileID: 0}
   grid: {fileID: 0}
+  consoleGrid: {fileID: 0}
   prefabDraggableBlock: {fileID: 1274260059464758, guid: d5b9c14df8255d8498eba274462873e5,
     type: 2}
   possibleBlocksJSON: {fileID: 4900000, guid: 9df281a5798308947b09bc5a2ba18b20, type: 3}
+  tuningJSON: {fileID: 4900000, guid: 7d1523919ff371542a4d2c54d7080ec6, type: 3}
+  tierCurrent: 0
+  vestigesPerBlock: 0
+  vestigeLevel: 1
+  screenTapping: {fileID: 0}
 --- !u!224 &224066489780245838
 RectTransform:
   m_ObjectHideFlags: 1

--- a/Assets/Prefabs/GameOver.prefab
+++ b/Assets/Prefabs/GameOver.prefab
@@ -378,6 +378,7 @@ MonoBehaviour:
   - {fileID: 1311757882570894}
   textGameOverReason: {fileID: 114089338938984636}
   score: {fileID: 0}
+  analytics: {fileID: 114017712063440150}
 --- !u!114 &114230764441667554
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/Assets/Scenes/MainScene.unity
+++ b/Assets/Scenes/MainScene.unity
@@ -2366,6 +2366,11 @@ Prefab:
       propertyPath: consoleGrid
       value: 
       objectReference: {fileID: 1125939173}
+    - target: {fileID: 114317254578232620, guid: 5fa388134b667384caa9615ae4b7045e,
+        type: 2}
+      propertyPath: scoreCounter
+      value: 
+      objectReference: {fileID: 1623308074}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 5fa388134b667384caa9615ae4b7045e, type: 2}
   m_IsPrefabParent: 0

--- a/Assets/Scenes/Menus/Settings.unity
+++ b/Assets/Scenes/Menus/Settings.unity
@@ -698,6 +698,140 @@ Prefab:
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 272ec4bd592b8456a82cf2e6e72aa73c, type: 2}
   m_IsPrefabParent: 0
+--- !u!1 &757966257
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 757966258}
+  - component: {fileID: 757966262}
+  - component: {fileID: 757966261}
+  - component: {fileID: 757966260}
+  - component: {fileID: 757966259}
+  m_Layer: 5
+  m_Name: Cheatpage
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &757966258
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 757966257}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.69444, y: 0.69444, z: 0.69444}
+  m_Children:
+  - {fileID: 1790534834}
+  m_Father: {fileID: 1551238750}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.3, y: 0.01}
+  m_AnchorMax: {x: 0.7, y: 0.09}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 132, y: 46.95685}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &757966259
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 757966257}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9ba647365e1fad74c9423edaa1aed7fc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &757966260
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 757966257}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 1392445389, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 757966261}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 757966259}
+        m_MethodName: GoToCheatPage
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_TypeName: UnityEngine.UI.Button+ButtonClickedEvent, UnityEngine.UI, Version=1.0.0.0,
+      Culture=neutral, PublicKeyToken=null
+--- !u!114 &757966261
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 757966257}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+--- !u!222 &757966262
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 757966257}
 --- !u!1 &1071584079
 GameObject:
   m_ObjectHideFlags: 0
@@ -995,6 +1129,7 @@ RectTransform:
   m_Children:
   - {fileID: 1759810169}
   - {fileID: 2079926053}
+  - {fileID: 757966258}
   m_Father: {fileID: 0}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -1381,6 +1516,92 @@ CanvasRenderer:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1759810168}
+--- !u!1 &1790534833
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1790534834}
+  - component: {fileID: 1790534837}
+  - component: {fileID: 1790534836}
+  - component: {fileID: 1790534835}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1790534834
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1790534833}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 757966258}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1790534835
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1790534833}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9ba647365e1fad74c9423edaa1aed7fc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1790534836
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1790534833}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 14
+    m_FontStyle: 0
+    m_BestFit: 1
+    m_MinSize: 10
+    m_MaxSize: 80
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Cheat
+--- !u!222 &1790534837
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1790534833}
 --- !u!1 &2009104806
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Menus/Title.unity
+++ b/Assets/Scenes/Menus/Title.unity
@@ -249,7 +249,7 @@ GameObject:
   - component: {fileID: 437046582}
   - component: {fileID: 437046585}
   m_Layer: 5
-  m_Name: Play
+  m_Name: PlayNormal
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -267,7 +267,7 @@ RectTransform:
   m_Children:
   - {fileID: 2097943870}
   m_Father: {fileID: 2095276172}
-  m_RootOrder: 1
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.25, y: 0.5}
   m_AnchorMax: {x: 0.75, y: 0.7}
@@ -316,7 +316,7 @@ MonoBehaviour:
       m_Calls:
       - m_Target: {fileID: 437046585}
         m_MethodName: GoToGamePlay
-        m_Mode: 1
+        m_Mode: 6
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
@@ -469,140 +469,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f25ce2338d78248b2b14db2c3e80e895, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1 &595703346
-GameObject:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
-  m_Component:
-  - component: {fileID: 595703347}
-  - component: {fileID: 595703351}
-  - component: {fileID: 595703350}
-  - component: {fileID: 595703349}
-  - component: {fileID: 595703348}
-  m_Layer: 5
-  m_Name: Cheatpage
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &595703347
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 595703346}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 795944205}
-  m_Father: {fileID: 2095276172}
-  m_RootOrder: 5
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.3, y: 0.01}
-  m_AnchorMax: {x: 0.7, y: 0.09}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &595703348
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 595703346}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 9ba647365e1fad74c9423edaa1aed7fc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &595703349
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 595703346}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 1392445389, guid: f70555f144d8491a825f0804e09c671c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Navigation:
-    m_Mode: 3
-    m_SelectOnUp: {fileID: 0}
-    m_SelectOnDown: {fileID: 0}
-    m_SelectOnLeft: {fileID: 0}
-    m_SelectOnRight: {fileID: 0}
-  m_Transition: 1
-  m_Colors:
-    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
-    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
-    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
-    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
-    m_ColorMultiplier: 1
-    m_FadeDuration: 0.1
-  m_SpriteState:
-    m_HighlightedSprite: {fileID: 0}
-    m_PressedSprite: {fileID: 0}
-    m_DisabledSprite: {fileID: 0}
-  m_AnimationTriggers:
-    m_NormalTrigger: Normal
-    m_HighlightedTrigger: Highlighted
-    m_PressedTrigger: Pressed
-    m_DisabledTrigger: Disabled
-  m_Interactable: 1
-  m_TargetGraphic: {fileID: 595703350}
-  m_OnClick:
-    m_PersistentCalls:
-      m_Calls:
-      - m_Target: {fileID: 595703348}
-        m_MethodName: GoToCheatPage
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-    m_TypeName: UnityEngine.UI.Button+ButtonClickedEvent, UnityEngine.UI, Version=1.0.0.0,
-      Culture=neutral, PublicKeyToken=null
---- !u!114 &595703350
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 595703346}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  m_Sprite: {fileID: 0}
-  m_Type: 0
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
---- !u!222 &595703351
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 595703346}
 --- !u!1 &597235003
 GameObject:
   m_ObjectHideFlags: 0
@@ -692,92 +558,6 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &795944204
-GameObject:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
-  m_Component:
-  - component: {fileID: 795944205}
-  - component: {fileID: 795944208}
-  - component: {fileID: 795944207}
-  - component: {fileID: 795944206}
-  m_Layer: 5
-  m_Name: Text
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &795944205
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 795944204}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 595703347}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &795944206
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 795944204}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 9ba647365e1fad74c9423edaa1aed7fc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &795944207
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 795944204}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
-  m_RaycastTarget: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  m_FontData:
-    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
-    m_FontSize: 14
-    m_FontStyle: 0
-    m_BestFit: 1
-    m_MinSize: 10
-    m_MaxSize: 80
-    m_Alignment: 4
-    m_AlignByGeometry: 0
-    m_RichText: 1
-    m_HorizontalOverflow: 0
-    m_VerticalOverflow: 0
-    m_LineSpacing: 1
-  m_Text: Cheat
---- !u!222 &795944208
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 795944204}
 --- !u!1 &906551808
 GameObject:
   m_ObjectHideFlags: 0
@@ -809,7 +589,7 @@ RectTransform:
   m_Children:
   - {fileID: 470354016}
   m_Father: {fileID: 2095276172}
-  m_RootOrder: 3
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.2, y: 0.22}
   m_AnchorMax: {x: 0.8, y: 0.32}
@@ -1006,7 +786,7 @@ RectTransform:
   m_Children:
   - {fileID: 1330076796}
   m_Father: {fileID: 2095276172}
-  m_RootOrder: 2
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.2, y: 0.35}
   m_AnchorMax: {x: 0.8, y: 0.45}
@@ -1208,6 +988,92 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f25ce2338d78248b2b14db2c3e80e895, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &1420853834
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1420853835}
+  - component: {fileID: 1420853838}
+  - component: {fileID: 1420853837}
+  - component: {fileID: 1420853836}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1420853835
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1420853834}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1575885152}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1420853836
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1420853834}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f25ce2338d78248b2b14db2c3e80e895, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1420853837
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1420853834}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0.5661765, b: 0.0039046337, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 70
+    m_FontStyle: 0
+    m_BestFit: 1
+    m_MinSize: 7
+    m_MaxSize: 150
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Play Zen Mode
+--- !u!222 &1420853838
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1420853834}
 --- !u!1 &1550580401
 GameObject:
   m_ObjectHideFlags: 0
@@ -1239,7 +1105,7 @@ RectTransform:
   m_Children:
   - {fileID: 33201283}
   m_Father: {fileID: 2095276172}
-  m_RootOrder: 4
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.2, y: 0.09}
   m_AnchorMax: {x: 0.8, y: 0.19}
@@ -1343,6 +1209,140 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9ba647365e1fad74c9423edaa1aed7fc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &1575885151
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1575885152}
+  - component: {fileID: 1575885156}
+  - component: {fileID: 1575885155}
+  - component: {fileID: 1575885154}
+  - component: {fileID: 1575885153}
+  m_Layer: 5
+  m_Name: PlayZen
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1575885152
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1575885151}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.9999936, y: 0.9999936, z: 0.9999936}
+  m_Children:
+  - {fileID: 1420853835}
+  m_Father: {fileID: 2095276172}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.25, y: 0.8}
+  m_AnchorMax: {x: 0.75, y: 0.9}
+  m_AnchoredPosition: {x: 0.000030517578, y: -0.00012207031}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1575885153
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1575885151}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9ba647365e1fad74c9423edaa1aed7fc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1575885154
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1575885151}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 1392445389, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1575885155}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1575885153}
+        m_MethodName: GoToGamePlay
+        m_Mode: 6
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 1
+        m_CallState: 2
+    m_TypeName: UnityEngine.UI.Button+ButtonClickedEvent, UnityEngine.UI, Version=1.0.0.0,
+      Culture=neutral, PublicKeyToken=null
+--- !u!114 &1575885155
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1575885151}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+--- !u!222 &1575885156
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1575885151}
 --- !u!1 &1776664515
 GameObject:
   m_ObjectHideFlags: 0
@@ -1655,11 +1655,11 @@ RectTransform:
   m_LocalScale: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 1858133104}
+  - {fileID: 1575885152}
   - {fileID: 437046581}
   - {fileID: 1283103057}
   - {fileID: 906551809}
   - {fileID: 1550580402}
-  - {fileID: 595703347}
   - {fileID: 1776664516}
   m_Father: {fileID: 0}
   m_RootOrder: 1

--- a/Assets/Scripts/Analytics/Analytics.cs
+++ b/Assets/Scripts/Analytics/Analytics.cs
@@ -34,16 +34,17 @@ public class Analytics : MonoBehaviour
     // Use this for initialization
     void Start()
     {
+        /*
         if (gameFlow != null)
         {
             gameFlow.GameLost += SendData;
         }
+        */
             
         settings = FindObjectOfType<Settings>(); //Can't pass in a reference because it's a singleton
-
     }
 
-    void SendData(GameFlow.GameOverCause cause)
+    public void SendData(GameFlow.GameOverCause cause, int highScore)
     {
         if (settings.AreCheatsEnabled())
         {
@@ -58,17 +59,10 @@ public class Analytics : MonoBehaviour
         int currentVestiges = vestiges.GetCurrentVestiges();
         int finalClearedSquares = clearedSquares.GetClearedSquares();
         float timePlaying = Time.time;
+        bool isZenMode = settings.IsZenModeEnabled();
         //string currentTimeStamp = System.DateTime.Now.ToString();
         //string allTheData = "timestamp;" + currentTimeStamp + ",score;" + finalScore + ",peakEnergy;" + peakEnergy + ",timePlaying;" + timePlaying + ",turnsPlayed;" + turnsPlayed + ",peakVestiges;" + peakVestiges + ",endingVestiges;" + currentVestiges + ",totalClearedSquares;" + finalClearedSquares;
         //Debug.Log("allTheData is" + allTheData);
-        //Find high score
-        int highScore = PlayerPrefs.GetInt("HighScore"); //Set our high score - will be 0 if doesn't exist
-        if (finalScore > highScore) //If our current score is higher
-        {
-            //Debug.Log("New High Score! Setting High Score.");
-            highScore = finalScore; //Set it to send to analytics
-            PlayerPrefs.SetInt("HighScore", highScore); //Save it
-        }
         UnityEngine.Analytics.Analytics.CustomEvent("gameOver", new Dictionary<string, object>
         {
             { "score", finalScore },
@@ -79,7 +73,8 @@ public class Analytics : MonoBehaviour
             { "peakVestiges", peakVestiges},
             { "endingVestiges", currentVestiges},
             { "totalClearedSquares", finalClearedSquares},
-            { "highScore", highScore}
+            { "highScore", highScore},
+            { "isZenMode", isZenMode }
             //{ "allTheData", allTheData} //I removed this because it wasn't working anyway
 
         });

--- a/Assets/Scripts/BlockSpawner.cs
+++ b/Assets/Scripts/BlockSpawner.cs
@@ -10,6 +10,48 @@ using SimpleJSON;
 
 public class BlockSpawner : MonoBehaviour
 {
+    // A block that exists within the bag.
+    // Contains additional data such as tier information.
+    class BagBlock
+    {
+        Block block;
+        List<int> tiers;
+
+        // Constructor.
+        public BagBlock(Block mblock, List<int> mtiers)
+        {
+            block = mblock;
+            tiers = mtiers;
+        }
+
+        // Returns true if the BagBlock is in the given tier.
+        public bool IsTier(int tier)
+        {
+            return tiers.Contains(tier);
+        }
+
+        // Returns true if the BagBlock is a junkyard-only block.
+        public bool IsJunkyardOnly()
+        {
+            int smallestTier = tiers[0];
+            for (int i = 1; i < tiers.Count; ++i)
+            {
+                int tier = tiers[i];
+                if (tier < smallestTier)
+                {
+                    smallestTier = tier;
+                }
+            }
+            return smallestTier > 0;
+        }
+
+        // Duplicates the contained Block and returns it.
+        public Block CreateBlock()
+        {
+            return new Block(block);
+        }
+    }
+
     [SerializeField]
     [Tooltip("The number of seconds between DraggableBlock spawns in the queue. Use -1 to disable this feature.")]
     float timeBetweenBlocks;
@@ -35,8 +77,11 @@ public class BlockSpawner : MonoBehaviour
     [Tooltip("Reference to the PossibleBlocks JSON, which determines the block designs.")]
     TextAsset possibleBlocksJSON;
     [SerializeField]
-    [Tooltip("The current junkyard tier. 0 = no junkyard event.")]
-    int tierCurrent = 0;
+    [Tooltip("Reference to the Tuning JSON.")]
+    TextAsset tuningJSON;
+    [SerializeField]
+    [Tooltip("The current junkyard tier. 0 = no junkyard event. -1 = friendly bag only.")]
+    int tierCurrent = -1;
     [SerializeField]
     [Tooltip("The current number of vestiges to generate per block.")]
     int vestigesPerBlock = 0;
@@ -46,9 +91,14 @@ public class BlockSpawner : MonoBehaviour
     [SerializeField]
     [Tooltip("Reference to ScreenTapping.")]
     ScreenTapping screenTapping;
+    [SerializeField]
+    [Tooltip("Reference to the ScoreCounter.")]
+    ScoreCounter scoreCounter;
 
-    List<Block>[] possibleBlocks = new List<Block>[4];
-    List<Block> bag = new List<Block>();
+    // List of all possible blocks that can be put into the bag.
+    List<BagBlock> possibleBlocks = new List<BagBlock>();
+    // List of blocks remaining in the bag.
+    List<BagBlock> bag = new List<BagBlock>();
 
     Queue<DraggableBlock> blocksQueue = new Queue<DraggableBlock>();
 
@@ -56,18 +106,31 @@ public class BlockSpawner : MonoBehaviour
     Block currentBlock;
     bool isSpawningSameBlocks;
     bool isSpawningOneTileBlocks;
+    // Keeps track of whether the block shall contain vestiges or not.
+    bool isContaminationBlock = true;
+    // Whether contamination blocks alternate or not.
+    bool doContaminationBlocksAlternate;
+    // The maximum score for the friendly bag. When the score becomes larger than this value,
+    // the friendly bag gets abandoned.
+    int friendlyBagMaxScore;
+    // Whether a junkyard event is currently starting.
+    bool junkyardEventIsStarting = false;
 
     private void Awake()
     {
-        for (int i = 0; i < 4; ++i)
+        tierCurrent = -1;
+        /*
+        foreach (int tier in tiers)
         {
-            possibleBlocks[i] = new List<Block>();
+            possibleBlocks.Add(tier, new List<Block>());
         }
+        */
     }
 
     private void Start()
     {
         gameFlow.GameLost += GameFlow_GameLost;
+        scoreCounter.ScoreChanged += ScoreCounter_ScoreChanged;
 
         // Make sure that we can't have more DraggableBlocks in the queue
         // than there are block positions!
@@ -77,25 +140,24 @@ public class BlockSpawner : MonoBehaviour
         }
     }
 
-    public void Init()
+    private void Tune()
     {
-        //read json file
-        var json = JSON.Parse(possibleBlocksJSON.ToString());
+        // Read PossibleBlocks JSON.
+        JSONNode json = JSON.Parse(possibleBlocksJSON.ToString());
 
         const string blocksNormal = "blocks";
 
         for (int i = 0; i < json[blocksNormal].Count; i++)
         {
-            Block block;
-            //int formation = Random.Range(0, json["blocks"].Count);
-            var w = json[blocksNormal][i]["width"].AsInt;
-            var h = json[blocksNormal][i]["height"].AsInt;
-            int sprite = json[blocksNormal][i]["sprite"].AsInt;
-            var cell = json[blocksNormal][i]["cells"].AsArray;
-            var tiers = json[blocksNormal][i]["tiers"].AsArray;
-            //Debug.Log(cell.ToString());
+            JSONNode blockNode = json[blocksNormal][i];
 
-            block = new Block(h, w);
+            int w = blockNode["width"].AsInt;
+            int h = blockNode["height"].AsInt;
+            int sprite = blockNode["sprite"].AsInt;
+            JSONArray cell = blockNode["cells"].AsArray;
+            JSONArray tiers = blockNode["tiers"].AsArray;
+
+            Block block = new Block(h, w);
 
             for (int row = 0; row < h; ++row)
             {
@@ -115,14 +177,24 @@ public class BlockSpawner : MonoBehaviour
                 }
             }
 
+            List<int> tierList = new List<int>();
             int numTiers = tiers.Count;
             for (int t = 0; t < numTiers; ++t)
             {
                 int tierID = tiers[t];
-                possibleBlocks[tierID].Add(block);
+                tierList.Add(tierID);
             }
+            possibleBlocks.Add(new BagBlock(block, tierList));
         }
 
+        json = JSON.Parse(tuningJSON.ToString());
+        doContaminationBlocksAlternate = json["contamination blocks alternate"].AsBool;
+        friendlyBagMaxScore = json["friendly bag max score"].AsInt;
+    }
+
+    public void Init()
+    {
+        Tune();
         ResetBlockTimer();
         SpawnRandomBlock();
     }
@@ -130,7 +202,8 @@ public class BlockSpawner : MonoBehaviour
     private void Update()
     {
         // if the timeBetweenBlocks is not -1 timer will function
-        if (timeBetweenBlocks != -1){
+        if (timeBetweenBlocks != -1)
+        {
             //Decrement the time until next block to spawn.
             //If reaching 0, spawn a new random block and 
             //reset the timer
@@ -139,9 +212,19 @@ public class BlockSpawner : MonoBehaviour
                 ResetBlockTimer();
                 SpawnRandomBlock();
             }
-            
+
             timeBeforeNextBlock -= Time.deltaTime;
         }
+    }
+
+    private List<BagBlock> GetBagBlocksOfTier(int tier)
+    {
+        return possibleBlocks.FindAll((BagBlock x) => x.IsTier(tier));
+    }
+
+    private List<BagBlock> GetBagBlocksJunkyardOnly()
+    {
+        return possibleBlocks.FindAll((BagBlock x) => x.IsJunkyardOnly());
     }
 
     public void ResetBlockTimer()
@@ -180,42 +263,88 @@ public class BlockSpawner : MonoBehaviour
             else if (isSpawningSameBlocks)
             {
                 if (currentBlock != null)
-                    toSpawn = currentBlock;                    
+                {
+                    toSpawn = currentBlock;
+                }
             }
             else
             {
+                // The index of the block to choose from the bag.
+                int indexInBagToChoose = -1;
                 if (bag.Count == 0)
                 {
                     // If the bag is empty, repopulate it.
-                    for (int j = 0; j < possibleBlocks[tierCurrent].Count; ++j)
+                    List<BagBlock> viableBlocks = GetBagBlocksOfTier(tierCurrent);
+                    for (int j = 0; j < viableBlocks.Count; ++j)
                     {
-                        bag.Add(new Block(possibleBlocks[tierCurrent][j]));
+                        //Block bagBlock = possibleBlocks[tierCurrent][j];
+                        //Block bagBlock = new Block(possibleBlocks[tierCurrent][j]);
+                        BagBlock viableBlock = viableBlocks[j];
+                        bag.Add(viableBlock);
+                    }
+                    // If a Junkyard event is starting, choose a junkyard-specific block.
+                    if (junkyardEventIsStarting)
+                    {
+                        junkyardEventIsStarting = false;
+
+                        List<BagBlock> junkyardBlocks = possibleBlocks.FindAll(
+                            x => x.IsTier(tierCurrent) && x.IsJunkyardOnly());
+
+                        int indexInJunkyardBlocks = Random.Range(0, junkyardBlocks.Count);
+                        BagBlock junkyardBlock = junkyardBlocks[indexInJunkyardBlocks];
+
+                        for (int j = 0; j < bag.Count; ++j)
+                        {
+                            BagBlock bagBlock = bag[j];
+                            if (bagBlock == junkyardBlock)
+                            {
+                                indexInBagToChoose = j;
+                                break;
+                            }
+                        }
+                        /*
+                        Debug.Log("Junkyard index / Bag index: " + indexInJunkyardBlocks +
+                            " / " + indexInBagToChoose);
+                            */
+                    }
+                    else
+                    {
+                        indexInBagToChoose = Random.Range(0, bag.Count);
                     }
                 }
-
-                int i = Random.Range(0, bag.Count);
-                toSpawn = bag[i];
+                else
+                {
+                    indexInBagToChoose = Random.Range(0, bag.Count);
+                }
+                toSpawn = bag[indexInBagToChoose].CreateBlock();
                 // Remove each chosen element from the bag.
-                bag.RemoveAt(i);
+                bag.RemoveAt(indexInBagToChoose);
 
                 // Add vestiges to the block, if applicable.
-                int vestigesAdded = 0;
-                List<TileData> refs = toSpawn.GetReferencesToType(TileData.TileType.Regular);
-
-                // Stop adding vestiges when there are no regular tiles left.
-                //Debug.Log("Vestige generation begin.");
-                while (vestigesAdded < vestigesPerBlock && refs.Count != 0)
+                if (isContaminationBlock)
                 {
-                    int index = Random.Range(0, refs.Count);
-                    TileData v = refs[index];
-                    v.Fill(TileData.TileType.Vestige);
-                    v.SetVestigeLevel(vestigeLevel);
-                    refs.RemoveAt(index);
-                    ++vestigesAdded;
-                    //Debug.Log("vestigesAdded / vestigesPerBlock: " + vestigesAdded + " / " + vestigesPerBlock);
-                    //Debug.Log("BlockSpawner: vestigeLevel: " + vestigeLevel);
+                    int vestigesAdded = 0;
+                    List<TileData> refs = toSpawn.GetReferencesToType(TileData.TileType.Regular);
+
+                    // Stop adding vestiges when there are no regular tiles left.
+                    //Debug.Log("Vestige generation begin.");
+                    while (vestigesAdded < vestigesPerBlock && refs.Count != 0)
+                    {
+                        int index = Random.Range(0, refs.Count);
+                        TileData v = refs[index];
+                        v.Fill(TileData.TileType.Vestige);
+                        v.SetVestigeLevel(vestigeLevel);
+                        refs.RemoveAt(index);
+                        ++vestigesAdded;
+                        //Debug.Log("vestigesAdded / vestigesPerBlock: " + vestigesAdded + " / " + vestigesPerBlock);
+                        //Debug.Log("BlockSpawner: vestigeLevel: " + vestigeLevel);
+                    }
                 }
                 //Debug.Log("Vestige generation end.");
+                if (doContaminationBlocksAlternate)
+                {
+                    isContaminationBlock = !isContaminationBlock;
+                }
             }
 
             // Instantiate the actual block.
@@ -352,6 +481,7 @@ public class BlockSpawner : MonoBehaviour
     public void SetVestigesPerBlock(int newVal)
     {
         vestigesPerBlock = newVal;
+        isContaminationBlock = true;
     }
 
     public void SetVestigeLevel(int newVal)
@@ -365,15 +495,10 @@ public class BlockSpawner : MonoBehaviour
         EnableFrontBlock();
     }
 
-    // Callback function for gameFlow's GameLost event.
-    private void GameFlow_GameLost(GameFlow.GameOverCause cause)
+    public void BeginJunkyardEvent()
     {
-        if (blocksQueue.Count > 0)
-        {
-            blocksQueue.Peek().AllowDragging(false);
-        }
-        enabled = false;
-    }	
+        junkyardEventIsStarting = true;
+    }
     
     //Will always spwan the same blocks as the current one
     public void CheatSpawning(bool on)
@@ -384,5 +509,24 @@ public class BlockSpawner : MonoBehaviour
     public void OneTileCheatSpawning(bool on)
     {
         isSpawningOneTileBlocks = on;
+    }
+
+    // Callback function for gameFlow's GameLost event.
+    private void GameFlow_GameLost(GameFlow.GameOverCause cause)
+    {
+        if (blocksQueue.Count > 0)
+        {
+            blocksQueue.Peek().AllowDragging(false);
+        }
+        enabled = false;
+    }
+
+    private void ScoreCounter_ScoreChanged(int newScore)
+    {
+        // If the score is high enough, abandon the friendly bag.
+        if (tierCurrent == -1 && newScore > friendlyBagMaxScore)
+        {
+            SetJunkyardTier(0);
+        }
     }
 }

--- a/Assets/Scripts/Grid.cs
+++ b/Assets/Scripts/Grid.cs
@@ -66,7 +66,7 @@ public class Grid : MonoBehaviour
     [Tooltip("Reference to energy transfer ball animator.")]
     Animator energyTransferBallController;
     [SerializeField]
-    [Tooltip("Whether or not asteroids can spawn in filled cells.")]
+    [Tooltip("Whether or not asteroids can spawn in filled cells. Populated by JSON.")]
     bool asteroidsCanSpawnInFilledCells;
     [SerializeField]
     [Tooltip("Placeholder sprite for square outline")]
@@ -188,7 +188,7 @@ public class Grid : MonoBehaviour
             t.Clear();
             t.SetSprite(TileData.TileType.Unoccupied);
             // Subscribe to events.
-            t.Changed += Tile_Changed;
+            //t.Changed += Tile_Changed;
         }
 
         //Instantiate spaces
@@ -685,6 +685,7 @@ public class Grid : MonoBehaviour
             foreach (Tile t in duplicatesRemoved)
             {
                 t.Clear();
+                energyCounter.AddEnergy(energyPerCell);
 
                 /*Vector3 tilePos = t.transform.position;
                 Vector3 energyTransferBallPos = energyTransferBallController.transform.position;
@@ -1581,6 +1582,7 @@ public class Grid : MonoBehaviour
     }
 
     // Callback function for when a tiletype is changed.
+    /*
     private void Tile_Changed(TileData.TileType newType)
     {
         //If a type is changed to Unoccupied, then add energyPerCell energy
@@ -1589,6 +1591,7 @@ public class Grid : MonoBehaviour
             energyCounter.AddEnergy(energyPerCell);
         }
     }
+    */
 
     private void OnSquareFormed(int size, Vector3 textPos)
     {

--- a/Assets/Scripts/ScoreCounter.cs
+++ b/Assets/Scripts/ScoreCounter.cs
@@ -58,7 +58,8 @@ public class ScoreCounter : MonoBehaviour
 
     private void UpdateScore()
     {
-	textScore.text = translator.Translate("Score") + score;
+        //textScore.text = translator.Translate("Score") + score;
+        textScore.text = "Score: " + score;
         OnScoreChanged(score);
     }
 

--- a/Assets/Scripts/Settings.cs
+++ b/Assets/Scripts/Settings.cs
@@ -1,14 +1,17 @@
-﻿//Author: Wm. Josiah Erikson
-//This very simple script is for holding persistent cross-scene settings
+﻿// Author(s): Wm. Josiah Erikson, Paul Calande
+// This very simple script is for holding persistent cross-scene settings.
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-public class Settings : MonoBehaviour {
+public class Settings : MonoBehaviour
+{
     [SerializeField]
     [Tooltip("Are cheats enabled? For debug viewing purposes only.")]
-    bool cheatsEnabled; //Are there cheats enabled or not?
-    bool oneTileCheatEnabled;
+    bool cheatsEnabled = false;
+    [SerializeField]
+    [Tooltip("Whether Zen Mode is enabled or not.")]
+    bool zenModeEnabled = false;
 
     private static Settings instance = null;
     public static Settings Instance
@@ -18,7 +21,6 @@ public class Settings : MonoBehaviour {
             return instance;
         }
     }
-
 
     void Awake()
     {
@@ -31,16 +33,25 @@ public class Settings : MonoBehaviour {
         DontDestroyOnLoad(gameObject);
     }
 
-
-    public bool AreCheatsEnabled () //Tell us whether cheats are enabled or not
+    public bool AreCheatsEnabled() //Tell us whether cheats are enabled or not
     {
         //Debug.Log("Cheats are enabled: " + cheatsEnabled);
         return cheatsEnabled;
     }
 
-    public void SetCheatsEnabled () //Set cheats enabled
+    public void SetCheatsEnabled() //Set cheats enabled
     {
         cheatsEnabled = true;
         //Debug.Log("Cheats are enabled: " + cheatsEnabled);
+    }
+
+    public void SetZenModeEnabled(bool on)
+    {
+        zenModeEnabled = on;
+    }
+
+    public bool IsZenModeEnabled()
+    {
+        return zenModeEnabled;
     }
 }

--- a/Assets/Scripts/Tip.cs
+++ b/Assets/Scripts/Tip.cs
@@ -23,7 +23,7 @@ public class Tip : MonoBehaviour {
         var json = JSON.Parse(tipJSON.ToString());
         tips = json["tips"].AsArray;
 		displayTip = tips [Random.Range (0, tips.Count)];
-		displayTip = translator.Translate (displayTip);
+		//displayTip = translator.Translate (displayTip);
 		GetComponent<Text>().text = displayTip;
 	}
 }

--- a/Assets/Scripts/UI/UIGameOver.cs
+++ b/Assets/Scripts/UI/UIGameOver.cs
@@ -21,7 +21,9 @@ public class UIGameOver : MonoBehaviour
 	[SerializeField]
 	[Tooltip("Reference to the Score Counter instance.")]
 	ScoreCounter score;
-
+    [SerializeField]
+    [Tooltip("Reference to the Analytics instance.")]
+    Analytics analytics;
 
 	UILanguages translator;
 
@@ -86,15 +88,27 @@ public class UIGameOver : MonoBehaviour
                 break;
         }
 
-		//textGameOverReason.text = translator.Translate(reason);
-        int highScore = PlayerPrefs.GetInt("HighScore"); //Get the stored high score - 0 if doesn't exist
+        string prefsEntry;
+        if (Settings.Instance.IsZenModeEnabled())
+        {
+            prefsEntry = "HighScoreZen";
+        }
+        else
+        {
+            prefsEntry = "HighScore";
+        }
+
+        int highScore = PlayerPrefs.GetInt(prefsEntry); //Get the stored high score - 0 if doesn't exist
         int finalScore = score.GetScore();
         if (finalScore > highScore)
         {
             highScore = finalScore;
+            PlayerPrefs.SetInt(prefsEntry, highScore); //Save it
         }
 
-		textGameOverReason.text = translator.Translate(reason) + translator.Translate("HighScore1") + highScore;
+        analytics.SendData(cause, highScore);
 
+        //textGameOverReason.text = translator.Translate(reason) + translator.Translate("HighScore1") + highScore;
+        textGameOverReason.text = reason + "\nHigh score: " + highScore;
     }
 }

--- a/Assets/Scripts/UI/UITitleMenus.cs
+++ b/Assets/Scripts/UI/UITitleMenus.cs
@@ -33,8 +33,9 @@ public class UITitleMenus : MonoBehaviour
         SceneManager.LoadScene("About");
         AudioController.Instance.MenuClick();
     }
-	public void GoToGamePlay() 
+	public void GoToGamePlay(bool isZenMode) 
 	{
+        Settings.Instance.SetZenModeEnabled(isZenMode);
 		SceneManager.LoadScene ("MainScene");
         AudioController.Instance.MenuClick();
         AudioController.Instance.StopMusic();

--- a/Assets/Scripts/VoidEventController.cs
+++ b/Assets/Scripts/VoidEventController.cs
@@ -176,8 +176,40 @@ public class VoidEventController : MonoBehaviour
             letterBindings.Add(letter, types[i]);
         }
 
-        // Read from tuning data.
-        Tune();
+        PrintLetterBindings();
+
+        // Don't do event stuff in Zen Mode.
+        if (!Settings.Instance.IsZenModeEnabled())
+        {
+            // Read from tuning data and populate event groups.
+            Tune();
+        }
+    }
+
+    private void PrintLetterBindings()
+    {
+        List<VoidEvent.EventType> orderedEvents = new List<VoidEvent.EventType>();
+        orderedEvents.Add(letterBindings['a']);
+        orderedEvents.Add(letterBindings['b']);
+        orderedEvents.Add(letterBindings['c']);
+        string printstr = "The order of events is: ";
+        foreach (VoidEvent.EventType type in orderedEvents)
+        {
+            switch (type)
+            {
+                case VoidEvent.EventType.Asteroids:
+                    printstr += "Asteroids";
+                    break;
+                case VoidEvent.EventType.Junkyard:
+                    printstr += "Junkyard";
+                    break;
+                case VoidEvent.EventType.Radiation:
+                    printstr += "Radiation";
+                    break;
+            }
+            printstr += " -> ";
+        }
+        Debug.Log(printstr);
     }
 
     // Read variables from JSON data.
@@ -246,6 +278,7 @@ public class VoidEventController : MonoBehaviour
             case VoidEvent.EventType.Junkyard:
                 Debug.Log("Junkyard " + tier + " begin.");
                 blockSpawner.SetJunkyardTier(tier);
+                blockSpawner.BeginJunkyardEvent();
                 break;
 
             case VoidEvent.EventType.Radiation:


### PR DESCRIPTION
- Added new "contamination blocks alternate" variable to Tuning.json that determines whether blocks in Radiation alternate between having wastes or not. It is currently set to true, meaning that blocks will alternate between having wastes and not having wastes.
- Added new "friendly bag max score" variable to Tuning.json. When the player's score is less than or equal to this value, only blocks from tier -1 will spawn. This score threshold is currently 0, meaning that the friendly bag will stop once the player has more than 0 points. I've added some blocks in PossibleBlocks.json to tier -1; Design is free to tweak however they see fit. Contamination events are guaranteed to begin with a contamination block.
- Junkyard events are now guaranteed to begin with a Junkyard-specific block (i.e. a block that is not part of tier 0 or tier -1).
- The cheats button on the main menu has been moved to the Settings page.
- Added Zen Mode. It can be accessed through a new button on the main menu. High score for Zen Mode is saved separately from the high score for Normal Mode. Analytics keeps track of whether the player played Zen Mode or not.
- Asteroids no longer give energy when they disappear from the Grid.
- Analytics no longer subscribes to GameFlow.GameLost. Instead, UIGameOver calls Analytics.SendData directly once the new high score is calculated.
- Big BlockSpawner refactor.
- Fixed reference errors in main scene caused by localization. This is a temporary fix until the last of the localization update is merged in tonight.