### PR TITLE
settings page slider overhaul

### DIFF
--- a/Assets/Prefabs/EnergyContainer.prefab
+++ b/Assets/Prefabs/EnergyContainer.prefab
@@ -74,12 +74,12 @@ GameObject:
   - component: {fileID: 222205002312227378}
   - component: {fileID: 114155966069386632}
   m_Layer: 5
-  m_Name: IconAsteroids
+  m_Name: IconNoEvent
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!1 &1198027083940074
 GameObject:
   m_ObjectHideFlags: 0
@@ -254,6 +254,23 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
+--- !u!1 &1773230563165628
+GameObject:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 224653032296295478}
+  - component: {fileID: 222200043219773600}
+  - component: {fileID: 114282387680994912}
+  m_Layer: 5
+  m_Name: IconAsteroids
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
 --- !u!1 &1815005718009280
 GameObject:
   m_ObjectHideFlags: 0
@@ -357,6 +374,33 @@ MonoBehaviour:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1165876033444476}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Sprite: {fileID: 21300000, guid: e8faf3e16ace7ba4fbbc4e302499f9e2, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+--- !u!114 &114282387680994912
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1773230563165628}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
@@ -809,6 +853,12 @@ CanvasRenderer:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1243157980227324}
+--- !u!222 &222200043219773600
+CanvasRenderer:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1773230563165628}
 --- !u!222 &222205002312227378
 CanvasRenderer:
   m_ObjectHideFlags: 1
@@ -984,6 +1034,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 224724905267745052}
+  - {fileID: 224653032296295478}
   - {fileID: 224645309603615206}
   - {fileID: 224666200764398922}
   - {fileID: 224332628023837978}
@@ -1046,7 +1097,7 @@ RectTransform:
   m_LocalScale: {x: 0.99999756, y: 0.99999756, z: 0.99999756}
   m_Children: []
   m_Father: {fileID: 224243084722189292}
-  m_RootOrder: 3
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.9, y: 0.5}
   m_AnchorMax: {x: 0.9, y: 0.5}
@@ -1069,7 +1120,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 15, y: -218.2}
+  m_AnchoredPosition: {x: 10, y: 250}
   m_SizeDelta: {x: 257, y: 700}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!224 &224484006560545138
@@ -1121,10 +1172,28 @@ RectTransform:
   m_LocalScale: {x: 0.99999756, y: 0.99999756, z: 0.99999756}
   m_Children: []
   m_Father: {fileID: 224243084722189292}
-  m_RootOrder: 1
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 50, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!224 &224653032296295478
+RectTransform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1773230563165628}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 224243084722189292}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.3, y: 0.5}
+  m_AnchorMax: {x: 0.3, y: 0.5}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 50, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
@@ -1139,7 +1208,7 @@ RectTransform:
   m_LocalScale: {x: 0.99999756, y: 0.99999756, z: 0.99999756}
   m_Children: []
   m_Father: {fileID: 224243084722189292}
-  m_RootOrder: 2
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.72, y: 0.5}
   m_AnchorMax: {x: 0.72, y: 0.5}
@@ -1171,16 +1240,16 @@ RectTransform:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1165876033444476}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalScale: {x: 1.000003, y: 1.000003, z: 1.000003}
   m_Children: []
   m_Father: {fileID: 224243084722189292}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.3, y: 0.5}
-  m_AnchorMax: {x: 0.3, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchorMin: {x: 0.1, y: 0.5}
+  m_AnchorMax: {x: 0.1, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -0.00012207031}
   m_SizeDelta: {x: 50, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!224 &224796398986307568
@@ -1200,7 +1269,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 10, y: -10}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!224 &224881231136147388
@@ -1214,7 +1283,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 224243084722189292}
-  m_RootOrder: 4
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.48, y: 0.13}
   m_AnchorMax: {x: 0.52, y: 0.87}

--- a/Assets/Prefabs/SettingsSlider.prefab
+++ b/Assets/Prefabs/SettingsSlider.prefab
@@ -1,0 +1,321 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1142505392986322}
+  m_IsPrefabParent: 1
+--- !u!1 &1011868212817120
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 224280706158541664}
+  - component: {fileID: 222373780892459794}
+  - component: {fileID: 114158808577517086}
+  m_Layer: 5
+  m_Name: Background
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &1142505392986322
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 224670000528526898}
+  m_Layer: 5
+  m_Name: SettingsSlider
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &1325058492721318
+GameObject:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 224795791543986622}
+  - component: {fileID: 222876897726463798}
+  - component: {fileID: 114638060448075816}
+  m_Layer: 5
+  m_Name: Fill
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &1552032714959306
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 224530468543999296}
+  m_Layer: 5
+  m_Name: Fill Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &1574484970552600
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 224655688004821648}
+  m_Layer: 5
+  m_Name: Handle Slide Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &1601190754540082
+GameObject:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 224762257661907586}
+  - component: {fileID: 222479012144195452}
+  - component: {fileID: 114663488092427754}
+  m_Layer: 5
+  m_Name: Handle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &114158808577517086
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1011868212817120}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Sprite: {fileID: 21300000, guid: 123af1e3dcdee1a458c672c70a0b264c, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+--- !u!114 &114638060448075816
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1325058492721318}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.0123270005, g: 0.83823526, b: 0.18890044, a: 0.627451}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+--- !u!114 &114663488092427754
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1601190754540082}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Sprite: {fileID: 21300000, guid: 87eb2e7b029853043957cefdd2abd3c9, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+--- !u!222 &222373780892459794
+CanvasRenderer:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1011868212817120}
+--- !u!222 &222479012144195452
+CanvasRenderer:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1601190754540082}
+--- !u!222 &222876897726463798
+CanvasRenderer:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1325058492721318}
+--- !u!224 &224280706158541664
+RectTransform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1011868212817120}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: -0.9499999, y: 0.6, z: 1}
+  m_Children: []
+  m_Father: {fileID: 224670000528526898}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.25}
+  m_AnchorMax: {x: 1, y: 0.75}
+  m_AnchoredPosition: {x: 0, y: 0.000012486807}
+  m_SizeDelta: {x: 60, y: -40}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!224 &224530468543999296
+RectTransform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1552032714959306}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 224795791543986622}
+  m_Father: {fileID: 224670000528526898}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.25}
+  m_AnchorMax: {x: 1, y: 0.75}
+  m_AnchoredPosition: {x: -5, y: 0.000012486807}
+  m_SizeDelta: {x: 40, y: -40}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!224 &224655688004821648
+RectTransform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1574484970552600}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 224762257661907586}
+  m_Father: {fileID: 224670000528526898}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0.000012486807}
+  m_SizeDelta: {x: 40, y: -80}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!224 &224670000528526898
+RectTransform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1142505392986322}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 224280706158541664}
+  - {fileID: 224530468543999296}
+  - {fileID: 224655688004821648}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -0.000015258789}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!224 &224762257661907586
+RectTransform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1601190754540082}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 224655688004821648}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 20, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!224 &224795791543986622
+RectTransform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1325058492721318}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 224530468543999296}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 10, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}

--- a/Assets/Prefabs/SettingsSlider.prefab.meta
+++ b/Assets/Prefabs/SettingsSlider.prefab.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: f73e4e7fcb544d14da9adc9f1397c465
+timeCreated: 1510974476
+licenseType: Free
+NativeFormatImporter:
+  mainObjectFileID: 100100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/Menus/Settings.unity
+++ b/Assets/Scenes/Menus/Settings.unity
@@ -108,74 +108,6 @@ NavMeshSettings:
     tileSize: 256
     accuratePlacement: 0
   m_NavMeshData: {fileID: 0}
---- !u!1 &112441728
-GameObject:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
-  m_Component:
-  - component: {fileID: 112441729}
-  - component: {fileID: 112441731}
-  - component: {fileID: 112441730}
-  m_Layer: 5
-  m_Name: Background
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &112441729
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 112441728}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 142031071}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0.25}
-  m_AnchorMax: {x: 1, y: 0.75}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &112441730
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 112441728}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
-  m_Type: 1
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
---- !u!222 &112441731
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 112441728}
 --- !u!1 &142031070
 GameObject:
   m_ObjectHideFlags: 0
@@ -203,9 +135,7 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 3.4368556, y: 3.436855, z: 3.436855}
   m_Children:
-  - {fileID: 112441729}
-  - {fileID: 1376399657}
-  - {fileID: 743723972}
+  - {fileID: 720667186}
   m_Father: {fileID: 1551238750}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -253,15 +183,15 @@ MonoBehaviour:
   m_FillRect: {fileID: 1225511361}
   m_HandleRect: {fileID: 2115325719}
   m_Direction: 0
-  m_MinValue: -50
-  m_MaxValue: 0
+  m_MinValue: 0
+  m_MaxValue: 1
   m_WholeNumbers: 0
-  m_Value: 0
+  m_Value: 1
   m_OnValueChanged:
     m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 142031073}
-        m_MethodName: ChangeMusicVol
+        m_MethodName: SliderChangeValue
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -284,44 +214,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0a4a83cb6cb63524d8181d98641c20ab, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  thisSlider: {fileID: 142031072}
-  btn: {fileID: 250822835}
-  music: 1
-  sfx: 0
---- !u!1 &157179562
-GameObject:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
-  m_Component:
-  - component: {fileID: 157179563}
-  m_Layer: 5
-  m_Name: Handle Slide Area
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &157179563
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 157179562}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 922760920}
-  m_Father: {fileID: 646423483}
-  m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: -20, y: 0}
-  m_Pivot: {x: 0.5, y: 0.5}
+  mixer: {fileID: 24100000, guid: ff98622eb62353c41a656249542fc88d, type: 2}
+  mixerParameter: musicVol
+  slider: {fileID: 142031072}
+  saveValuesToDisk: 1
 --- !u!1 &214056357
 GameObject:
   m_ObjectHideFlags: 0
@@ -449,6 +345,8 @@ GameObject:
   - component: {fileID: 250822836}
   - component: {fileID: 250822835}
   - component: {fileID: 250822834}
+  - component: {fileID: 250822837}
+  - component: {fileID: 250822838}
   m_Layer: 5
   m_Name: ButtonMuteMusic
   m_TagString: Untagged
@@ -464,16 +362,17 @@ RectTransform:
   m_GameObject: {fileID: 250822832}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 2.5996878, z: 1}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
-  - {fileID: 1807229856}
+  - {fileID: 893214604}
+  - {fileID: 1502357890}
   m_Father: {fileID: 1551238750}
-  m_RootOrder: 7
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: -403, y: 0}
-  m_SizeDelta: {x: 160, y: 30}
+  m_SizeDelta: {x: 160, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &250822834
 MonoBehaviour:
@@ -515,7 +414,18 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 142031073}
-        m_MethodName: MuteMusic
+        m_MethodName: ToggleMute
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 250822838}
+        m_MethodName: PlayButtonSound
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -560,6 +470,30 @@ CanvasRenderer:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 250822832}
+--- !u!114 &250822837
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 250822832}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6ca063964c2bf2d418091629e5f5cd8b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  audioSlider: {fileID: 142031073}
+  muteButtonCrossout: {fileID: 1502357889}
+--- !u!114 &250822838
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 250822832}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9ba647365e1fad74c9423edaa1aed7fc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &398955470
 GameObject:
   m_ObjectHideFlags: 0
@@ -929,7 +863,7 @@ RectTransform:
   m_LocalScale: {x: 3.226275, y: 3.226275, z: 3.226275}
   m_Children: []
   m_Father: {fileID: 1551238750}
-  m_RootOrder: 6
+  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -1002,9 +936,7 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 3.436854, y: 3.436854, z: 3.436854}
   m_Children:
-  - {fileID: 1574374821}
-  - {fileID: 1800878232}
-  - {fileID: 157179563}
+  - {fileID: 1574725867}
   m_Father: {fileID: 1551238750}
   m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -1048,19 +980,19 @@ MonoBehaviour:
     m_PressedTrigger: Pressed
     m_DisabledTrigger: Disabled
   m_Interactable: 1
-  m_TargetGraphic: {fileID: 922760921}
-  m_FillRect: {fileID: 1046266575}
-  m_HandleRect: {fileID: 922760920}
+  m_TargetGraphic: {fileID: 1574725869}
+  m_FillRect: {fileID: 1574725868}
+  m_HandleRect: {fileID: 1574725866}
   m_Direction: 0
-  m_MinValue: -50
-  m_MaxValue: 0
+  m_MinValue: 0
+  m_MaxValue: 1
   m_WholeNumbers: 0
-  m_Value: 0
+  m_Value: 1
   m_OnValueChanged:
     m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 646423485}
-        m_MethodName: ChangeSFXVol
+        m_MethodName: SliderChangeValue
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -1083,10 +1015,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0a4a83cb6cb63524d8181d98641c20ab, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  thisSlider: {fileID: 646423484}
-  btn: {fileID: 1998297104}
-  music: 0
-  sfx: 1
+  mixer: {fileID: 24100000, guid: ff98622eb62353c41a656249542fc88d, type: 2}
+  mixerParameter: sfxVol
+  slider: {fileID: 646423484}
+  saveValuesToDisk: 1
 --- !u!1001 &651399351
 Prefab:
   m_ObjectHideFlags: 0
@@ -1134,114 +1066,136 @@ Prefab:
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 272ec4bd592b8456a82cf2e6e72aa73c, type: 2}
   m_IsPrefabParent: 0
---- !u!1 &742072892
-GameObject:
+--- !u!1001 &720667185
+Prefab:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
-  m_Component:
-  - component: {fileID: 742072893}
-  - component: {fileID: 742072895}
-  - component: {fileID: 742072894}
-  m_Layer: 5
-  m_Name: Text
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &742072893
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 142031071}
+    m_Modifications:
+    - target: {fileID: 224670000528526898, guid: f73e4e7fcb544d14da9adc9f1397c465,
+        type: 2}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224670000528526898, guid: f73e4e7fcb544d14da9adc9f1397c465,
+        type: 2}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224670000528526898, guid: f73e4e7fcb544d14da9adc9f1397c465,
+        type: 2}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224670000528526898, guid: f73e4e7fcb544d14da9adc9f1397c465,
+        type: 2}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224670000528526898, guid: f73e4e7fcb544d14da9adc9f1397c465,
+        type: 2}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224670000528526898, guid: f73e4e7fcb544d14da9adc9f1397c465,
+        type: 2}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224670000528526898, guid: f73e4e7fcb544d14da9adc9f1397c465,
+        type: 2}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 224670000528526898, guid: f73e4e7fcb544d14da9adc9f1397c465,
+        type: 2}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224670000528526898, guid: f73e4e7fcb544d14da9adc9f1397c465,
+        type: 2}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224670000528526898, guid: f73e4e7fcb544d14da9adc9f1397c465,
+        type: 2}
+      propertyPath: m_AnchoredPosition.y
+      value: -0.000015258789
+      objectReference: {fileID: 0}
+    - target: {fileID: 224670000528526898, guid: f73e4e7fcb544d14da9adc9f1397c465,
+        type: 2}
+      propertyPath: m_SizeDelta.x
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 224670000528526898, guid: f73e4e7fcb544d14da9adc9f1397c465,
+        type: 2}
+      propertyPath: m_SizeDelta.y
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 224670000528526898, guid: f73e4e7fcb544d14da9adc9f1397c465,
+        type: 2}
+      propertyPath: m_AnchorMin.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 224670000528526898, guid: f73e4e7fcb544d14da9adc9f1397c465,
+        type: 2}
+      propertyPath: m_AnchorMin.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 224670000528526898, guid: f73e4e7fcb544d14da9adc9f1397c465,
+        type: 2}
+      propertyPath: m_AnchorMax.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 224670000528526898, guid: f73e4e7fcb544d14da9adc9f1397c465,
+        type: 2}
+      propertyPath: m_AnchorMax.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 224670000528526898, guid: f73e4e7fcb544d14da9adc9f1397c465,
+        type: 2}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 224670000528526898, guid: f73e4e7fcb544d14da9adc9f1397c465,
+        type: 2}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 224795791543986622, guid: f73e4e7fcb544d14da9adc9f1397c465,
+        type: 2}
+      propertyPath: m_AnchorMax.x
+      value: 0.006
+      objectReference: {fileID: 0}
+    - target: {fileID: 224795791543986622, guid: f73e4e7fcb544d14da9adc9f1397c465,
+        type: 2}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 224762257661907586, guid: f73e4e7fcb544d14da9adc9f1397c465,
+        type: 2}
+      propertyPath: m_AnchorMin.x
+      value: 0.006
+      objectReference: {fileID: 0}
+    - target: {fileID: 224762257661907586, guid: f73e4e7fcb544d14da9adc9f1397c465,
+        type: 2}
+      propertyPath: m_AnchorMax.x
+      value: 0.006
+      objectReference: {fileID: 0}
+    - target: {fileID: 224762257661907586, guid: f73e4e7fcb544d14da9adc9f1397c465,
+        type: 2}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 100100000, guid: f73e4e7fcb544d14da9adc9f1397c465, type: 2}
+  m_IsPrefabParent: 0
+--- !u!224 &720667186 stripped
 RectTransform:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 742072892}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1998297102}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &742072894
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 742072892}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
-  m_RaycastTarget: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  m_FontData:
-    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
-    m_FontSize: 14
-    m_FontStyle: 0
-    m_BestFit: 0
-    m_MinSize: 10
-    m_MaxSize: 40
-    m_Alignment: 4
-    m_AlignByGeometry: 0
-    m_RichText: 1
-    m_HorizontalOverflow: 0
-    m_VerticalOverflow: 0
-    m_LineSpacing: 1
-  m_Text: 
---- !u!222 &742072895
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 742072892}
---- !u!1 &743723971
-GameObject:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
-  m_Component:
-  - component: {fileID: 743723972}
-  m_Layer: 5
-  m_Name: Handle Slide Area
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &743723972
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 743723971}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 2115325719}
-  m_Father: {fileID: 142031071}
-  m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: -20, y: 0}
-  m_Pivot: {x: 0.5, y: 0.5}
+  m_PrefabParentObject: {fileID: 224670000528526898, guid: f73e4e7fcb544d14da9adc9f1397c465,
+    type: 2}
+  m_PrefabInternal: {fileID: 720667185}
 --- !u!1 &757966257
 GameObject:
   m_ObjectHideFlags: 0
@@ -1418,47 +1372,47 @@ Prefab:
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: ea7a4f0fb977fdf4fabf18536a098fd9, type: 2}
   m_IsPrefabParent: 0
---- !u!1 &922760919
+--- !u!1 &893214603
 GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   serializedVersion: 5
   m_Component:
-  - component: {fileID: 922760920}
-  - component: {fileID: 922760922}
-  - component: {fileID: 922760921}
+  - component: {fileID: 893214604}
+  - component: {fileID: 893214606}
+  - component: {fileID: 893214605}
   m_Layer: 5
-  m_Name: Handle
+  m_Name: Icon
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!224 &922760920
+--- !u!224 &893214604
 RectTransform:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 922760919}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_GameObject: {fileID: 893214603}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
-  m_Father: {fileID: 157179563}
+  m_Father: {fileID: 250822833}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
+  m_AnchorMin: {x: 0.2, y: 0.1}
+  m_AnchorMax: {x: 0.8, y: 0.9}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 20, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &922760921
+--- !u!114 &893214605
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 922760919}
+  m_GameObject: {fileID: 893214603}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
@@ -1472,88 +1426,20 @@ MonoBehaviour:
       m_Calls: []
     m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
       Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  m_Sprite: {fileID: 10913, guid: 0000000000000000f000000000000000, type: 0}
+  m_Sprite: {fileID: 21300000, guid: 5cf18e435d8c8124e9aedc5e303b61db, type: 3}
   m_Type: 0
-  m_PreserveAspect: 0
+  m_PreserveAspect: 1
   m_FillCenter: 1
   m_FillMethod: 4
   m_FillAmount: 1
   m_FillClockwise: 1
   m_FillOrigin: 0
---- !u!222 &922760922
+--- !u!222 &893214606
 CanvasRenderer:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 922760919}
---- !u!1 &1046266574
-GameObject:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
-  m_Component:
-  - component: {fileID: 1046266575}
-  - component: {fileID: 1046266577}
-  - component: {fileID: 1046266576}
-  m_Layer: 5
-  m_Name: Fill
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &1046266575
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1046266574}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1800878232}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 10, y: 0}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &1046266576
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1046266574}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
-  m_Type: 1
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
---- !u!222 &1046266577
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1046266574}
+  m_GameObject: {fileID: 893214603}
 --- !u!1 &1071584079
 GameObject:
   m_ObjectHideFlags: 0
@@ -1796,108 +1682,147 @@ Prefab:
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 27a27589748ded645867762d6f8ea1b9, type: 2}
   m_IsPrefabParent: 0
---- !u!1 &1225511360
+--- !u!224 &1225511361 stripped
+RectTransform:
+  m_PrefabParentObject: {fileID: 224795791543986622, guid: f73e4e7fcb544d14da9adc9f1397c465,
+    type: 2}
+  m_PrefabInternal: {fileID: 720667185}
+--- !u!1 &1293720689
 GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   serializedVersion: 5
   m_Component:
-  - component: {fileID: 1225511361}
-  - component: {fileID: 1225511363}
-  - component: {fileID: 1225511362}
+  - component: {fileID: 1293720690}
+  - component: {fileID: 1293720692}
+  - component: {fileID: 1293720691}
   m_Layer: 5
-  m_Name: Fill
+  m_Name: Crossout
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!224 &1225511361
+--- !u!224 &1293720690
 RectTransform:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1225511360}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_GameObject: {fileID: 1293720689}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalScale: {x: 0.99999845, y: 0.99999845, z: 0.99999845}
   m_Children: []
-  m_Father: {fileID: 1376399657}
-  m_RootOrder: 0
+  m_Father: {fileID: 1998297102}
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 10, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &1225511362
+--- !u!114 &1293720691
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1225511360}
+  m_GameObject: {fileID: 1293720689}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Color: {r: 1, g: 0, b: 0, a: 0.5019608}
   m_RaycastTarget: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
     m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
       Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
-  m_Type: 1
+  m_Sprite: {fileID: 0}
+  m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1
   m_FillMethod: 4
   m_FillAmount: 1
   m_FillClockwise: 1
   m_FillOrigin: 0
---- !u!222 &1225511363
+--- !u!222 &1293720692
 CanvasRenderer:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1225511360}
---- !u!1 &1376399656
+  m_GameObject: {fileID: 1293720689}
+--- !u!1 &1502357889
 GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   serializedVersion: 5
   m_Component:
-  - component: {fileID: 1376399657}
+  - component: {fileID: 1502357890}
+  - component: {fileID: 1502357892}
+  - component: {fileID: 1502357891}
   m_Layer: 5
-  m_Name: Fill Area
+  m_Name: Crossout
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!224 &1376399657
+--- !u!224 &1502357890
 RectTransform:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1376399656}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_GameObject: {fileID: 1502357889}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 1225511361}
-  m_Father: {fileID: 142031071}
+  m_Children: []
+  m_Father: {fileID: 250822833}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0.25}
-  m_AnchorMax: {x: 1, y: 0.75}
-  m_AnchoredPosition: {x: -5, y: 0}
-  m_SizeDelta: {x: -20, y: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1502357891
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1502357889}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 0, b: 0, a: 0.5019608}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+--- !u!222 &1502357892
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1502357889}
 --- !u!1 &1504623039
 GameObject:
   m_ObjectHideFlags: 0
@@ -2050,10 +1975,10 @@ RectTransform:
   - {fileID: 757966258}
   - {fileID: 142031071}
   - {fileID: 646423483}
-  - {fileID: 1812409138}
-  - {fileID: 598905064}
   - {fileID: 250822833}
   - {fileID: 1998297102}
+  - {fileID: 1812409138}
+  - {fileID: 598905064}
   m_Father: {fileID: 0}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -2062,74 +1987,152 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
---- !u!1 &1574374820
-GameObject:
+--- !u!1001 &1574725865
+Prefab:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
-  m_Component:
-  - component: {fileID: 1574374821}
-  - component: {fileID: 1574374823}
-  - component: {fileID: 1574374822}
-  m_Layer: 5
-  m_Name: Background
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &1574374821
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 646423483}
+    m_Modifications:
+    - target: {fileID: 224670000528526898, guid: f73e4e7fcb544d14da9adc9f1397c465,
+        type: 2}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224670000528526898, guid: f73e4e7fcb544d14da9adc9f1397c465,
+        type: 2}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224670000528526898, guid: f73e4e7fcb544d14da9adc9f1397c465,
+        type: 2}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224670000528526898, guid: f73e4e7fcb544d14da9adc9f1397c465,
+        type: 2}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224670000528526898, guid: f73e4e7fcb544d14da9adc9f1397c465,
+        type: 2}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224670000528526898, guid: f73e4e7fcb544d14da9adc9f1397c465,
+        type: 2}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224670000528526898, guid: f73e4e7fcb544d14da9adc9f1397c465,
+        type: 2}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 224670000528526898, guid: f73e4e7fcb544d14da9adc9f1397c465,
+        type: 2}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224670000528526898, guid: f73e4e7fcb544d14da9adc9f1397c465,
+        type: 2}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 224670000528526898, guid: f73e4e7fcb544d14da9adc9f1397c465,
+        type: 2}
+      propertyPath: m_AnchoredPosition.y
+      value: -0.000015258789
+      objectReference: {fileID: 0}
+    - target: {fileID: 224670000528526898, guid: f73e4e7fcb544d14da9adc9f1397c465,
+        type: 2}
+      propertyPath: m_SizeDelta.x
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 224670000528526898, guid: f73e4e7fcb544d14da9adc9f1397c465,
+        type: 2}
+      propertyPath: m_SizeDelta.y
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 224670000528526898, guid: f73e4e7fcb544d14da9adc9f1397c465,
+        type: 2}
+      propertyPath: m_AnchorMin.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 224670000528526898, guid: f73e4e7fcb544d14da9adc9f1397c465,
+        type: 2}
+      propertyPath: m_AnchorMin.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 224670000528526898, guid: f73e4e7fcb544d14da9adc9f1397c465,
+        type: 2}
+      propertyPath: m_AnchorMax.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 224670000528526898, guid: f73e4e7fcb544d14da9adc9f1397c465,
+        type: 2}
+      propertyPath: m_AnchorMax.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 224670000528526898, guid: f73e4e7fcb544d14da9adc9f1397c465,
+        type: 2}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 224670000528526898, guid: f73e4e7fcb544d14da9adc9f1397c465,
+        type: 2}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 224762257661907586, guid: f73e4e7fcb544d14da9adc9f1397c465,
+        type: 2}
+      propertyPath: m_AnchorMin.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 224762257661907586, guid: f73e4e7fcb544d14da9adc9f1397c465,
+        type: 2}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 224762257661907586, guid: f73e4e7fcb544d14da9adc9f1397c465,
+        type: 2}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 224795791543986622, guid: f73e4e7fcb544d14da9adc9f1397c465,
+        type: 2}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 224795791543986622, guid: f73e4e7fcb544d14da9adc9f1397c465,
+        type: 2}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 100100000, guid: f73e4e7fcb544d14da9adc9f1397c465, type: 2}
+  m_IsPrefabParent: 0
+--- !u!224 &1574725866 stripped
 RectTransform:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1574374820}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 646423483}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0.25}
-  m_AnchorMax: {x: 1, y: 0.75}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &1574374822
+  m_PrefabParentObject: {fileID: 224762257661907586, guid: f73e4e7fcb544d14da9adc9f1397c465,
+    type: 2}
+  m_PrefabInternal: {fileID: 1574725865}
+--- !u!224 &1574725867 stripped
+RectTransform:
+  m_PrefabParentObject: {fileID: 224670000528526898, guid: f73e4e7fcb544d14da9adc9f1397c465,
+    type: 2}
+  m_PrefabInternal: {fileID: 1574725865}
+--- !u!224 &1574725868 stripped
+RectTransform:
+  m_PrefabParentObject: {fileID: 224795791543986622, guid: f73e4e7fcb544d14da9adc9f1397c465,
+    type: 2}
+  m_PrefabInternal: {fileID: 1574725865}
+--- !u!114 &1574725869 stripped
 MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1574374820}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
+  m_PrefabParentObject: {fileID: 114663488092427754, guid: f73e4e7fcb544d14da9adc9f1397c465,
+    type: 2}
+  m_PrefabInternal: {fileID: 1574725865}
   m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
-  m_Type: 1
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
---- !u!222 &1574374823
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1574374820}
 --- !u!1 &1617608369
 GameObject:
   m_ObjectHideFlags: 0
@@ -2286,6 +2289,74 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_ShowMaskGraphic: 0
+--- !u!1 &1699936980
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1699936981}
+  - component: {fileID: 1699936983}
+  - component: {fileID: 1699936982}
+  m_Layer: 5
+  m_Name: Icon
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1699936981
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1699936980}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1998297102}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.2, y: 0.1}
+  m_AnchorMax: {x: 0.8, y: 0.9}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1699936982
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1699936980}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Sprite: {fileID: 21300000, guid: c0b14f22fb8507c4493a99c3539d55ba, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 1
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+--- !u!222 &1699936983
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1699936980}
 --- !u!1 &1756223743
 GameObject:
   m_ObjectHideFlags: 0
@@ -2596,114 +2667,6 @@ CanvasRenderer:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1790534833}
---- !u!1 &1800878231
-GameObject:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
-  m_Component:
-  - component: {fileID: 1800878232}
-  m_Layer: 5
-  m_Name: Fill Area
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &1800878232
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1800878231}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 1046266575}
-  m_Father: {fileID: 646423483}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0.25}
-  m_AnchorMax: {x: 1, y: 0.75}
-  m_AnchoredPosition: {x: -5, y: 0}
-  m_SizeDelta: {x: -20, y: 0}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!1 &1807229855
-GameObject:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
-  m_Component:
-  - component: {fileID: 1807229856}
-  - component: {fileID: 1807229858}
-  - component: {fileID: 1807229857}
-  m_Layer: 5
-  m_Name: Text
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &1807229856
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1807229855}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 250822833}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &1807229857
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1807229855}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
-  m_RaycastTarget: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  m_FontData:
-    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
-    m_FontSize: 14
-    m_FontStyle: 0
-    m_BestFit: 0
-    m_MinSize: 10
-    m_MaxSize: 40
-    m_Alignment: 4
-    m_AlignByGeometry: 0
-    m_RichText: 1
-    m_HorizontalOverflow: 0
-    m_VerticalOverflow: 0
-    m_LineSpacing: 1
-  m_Text: 
---- !u!222 &1807229858
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1807229855}
 --- !u!1 &1812409137
 GameObject:
   m_ObjectHideFlags: 0
@@ -2732,7 +2695,7 @@ RectTransform:
   m_LocalScale: {x: 3.2262733, y: 3.226274, z: 3.226274}
   m_Children: []
   m_Father: {fileID: 1551238750}
-  m_RootOrder: 5
+  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -2789,6 +2752,8 @@ GameObject:
   - component: {fileID: 1998297105}
   - component: {fileID: 1998297104}
   - component: {fileID: 1998297103}
+  - component: {fileID: 1998297106}
+  - component: {fileID: 1998297107}
   m_Layer: 5
   m_Name: ButtonMuteSFX
   m_TagString: Untagged
@@ -2804,16 +2769,17 @@ RectTransform:
   m_GameObject: {fileID: 1998297101}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0.99999845, y: 2.5996852, z: 0.99999845}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
-  - {fileID: 742072893}
+  - {fileID: 1699936981}
+  - {fileID: 1293720690}
   m_Father: {fileID: 1551238750}
-  m_RootOrder: 8
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: -403, y: -250}
-  m_SizeDelta: {x: 160, y: 30}
+  m_SizeDelta: {x: 160, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1998297103
 MonoBehaviour:
@@ -2855,7 +2821,18 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 646423485}
-        m_MethodName: MuteSFX
+        m_MethodName: ToggleMute
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 1998297107}
+        m_MethodName: PlayButtonSound
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -2900,6 +2877,30 @@ CanvasRenderer:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1998297101}
+--- !u!114 &1998297106
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1998297101}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6ca063964c2bf2d418091629e5f5cd8b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  audioSlider: {fileID: 646423485}
+  muteButtonCrossout: {fileID: 1293720689}
+--- !u!114 &1998297107
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1998297101}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9ba647365e1fad74c9423edaa1aed7fc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &2007559703
 GameObject:
   m_ObjectHideFlags: 0
@@ -3082,71 +3083,14 @@ RectTransform:
   m_PrefabParentObject: {fileID: 224607912779322094, guid: 27a27589748ded645867762d6f8ea1b9,
     type: 2}
   m_PrefabInternal: {fileID: 1214117229}
---- !u!1 &2115325718
-GameObject:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
-  m_Component:
-  - component: {fileID: 2115325719}
-  - component: {fileID: 2115325721}
-  - component: {fileID: 2115325720}
-  m_Layer: 5
-  m_Name: Handle
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &2115325719
+--- !u!224 &2115325719 stripped
 RectTransform:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 2115325718}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 743723972}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 20, y: 0}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &2115325720
+  m_PrefabParentObject: {fileID: 224762257661907586, guid: f73e4e7fcb544d14da9adc9f1397c465,
+    type: 2}
+  m_PrefabInternal: {fileID: 720667185}
+--- !u!114 &2115325720 stripped
 MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 2115325718}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
+  m_PrefabParentObject: {fileID: 114663488092427754, guid: f73e4e7fcb544d14da9adc9f1397c465,
+    type: 2}
+  m_PrefabInternal: {fileID: 720667185}
   m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  m_Sprite: {fileID: 10913, guid: 0000000000000000f000000000000000, type: 0}
-  m_Type: 0
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
---- !u!222 &2115325721
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 2115325718}

--- a/Assets/Scripts/AudioController.cs
+++ b/Assets/Scripts/AudioController.cs
@@ -10,7 +10,7 @@ using System.Collections.Generic;
 using System;
 using UnityEngine;
 using UnityEngine.Audio;
-using UnityEngine.SceneManagement;
+//using UnityEngine.SceneManagement;
 
 public class AudioController : MonoBehaviour
 {
@@ -32,9 +32,14 @@ public class AudioController : MonoBehaviour
 
     //public AudioSource currentlyPlaying;
 
+    AudioMixer thisMixer;
+
     [SerializeField]
     [Tooltip("Reference to the music audio source.")]
     AudioSource musicSource;
+
+    [SerializeField]
+    GameObject go;
 
     private static AudioController instance = null;
     public static AudioController Instance
@@ -44,7 +49,6 @@ public class AudioController : MonoBehaviour
             return instance;
         }
     }
-
 
     void Awake()
     {
@@ -59,81 +63,17 @@ public class AudioController : MonoBehaviour
 
         //PlayMusic(sceneMusic);
 
+        thisMixer = musicGroup.audioMixer;
+
         DontDestroyOnLoad(gameObject);
-        //SceneManager.activeSceneChanged += SceneManager_SceneChanged;
     }
 
-    /*
-    private void OnDestroy()
-    {
-        SceneManager.activeSceneChanged -= SceneManager_SceneChanged;
-    }
-    */
-
-    /*
     private void Start()
     {
-        Scene currentScene = SceneManager.GetActiveScene();
-        string sceneName = currentScene.name;
-
-        /*
-        if (currentScene.name != "MainScene")
-        {
-            if (currentlyPlaying.clip == null)
-            {
-                PlayMusic("Main_Menu_Music_1");
-            }
-            else
-            {
-                if (currentlyPlaying.clip.name == "Gameplay_Music_1")
-                {
-                    PlayMusic("Main_Menu_Music_1");
-                }
-            }
-        }
-        else
-        {
-            PlayMusic("Gameplay_Music_1");
-        }
+        // Unfortunately, mixer values cannot be set within Awake.
+        AudioSlider.LoadValueIntoMixer(thisMixer, "musicVol");
+        AudioSlider.LoadValueIntoMixer(thisMixer, "sfxVol");
     }
-    */
-
-    /*
-    public void PlayMusic(string musicName)
-    {
-        AudioClip clip = GetMusic(musicName);
-
-        if (clip == null)
-        {
-            CreateMusicChannel(clip);
-        }
-    }
-    */
-
-    /*
-    public void CreateMusicChannel()
-    {
-        AudioSource newChannel = gameObject.AddComponent<AudioSource>();
-        Channels.Add(newChannel);
-        //newChannel.clip = clip;
-        newChannel.outputAudioMixerGroup = musicGroup;
-        newChannel.loop = true;
-        newChannel.Play();
-        currentlyPlaying = newChannel;
-    }
-    */
-
-    /*
-    public void StopMusic()
-    {
-        if (currentlyPlaying != null)
-        {
-            currentlyPlaying.Stop();
-            Channels.Remove(currentlyPlaying);
-            currentlyPlaying = null;
-        }
-    }
-    */
 
     public void PlayMusic(AudioClip clip)
     {

--- a/Assets/Scripts/UI/AudioSlider.cs
+++ b/Assets/Scripts/UI/AudioSlider.cs
@@ -1,130 +1,196 @@
-﻿using System.Collections;
+﻿// Author(s): Paul Calande, Joel Esquilin
+// Script for a slider that controls audio.
+// The slider's range should be [0, 1], meaning 0% to 100% volume.
+
+using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Events;
 using UnityEngine.EventSystems;
 using UnityEngine.UI;
+using UnityEngine.Audio;
 
-public class AudioSlider : MonoBehaviour  {
+public class AudioSlider : MonoBehaviour, IPointerUpHandler
+{
+    // Invoked when the mute status changes. The argument is the new mute state.
+    public delegate void MuteUpdatedHandler(bool isMuted);
+    public event MuteUpdatedHandler MuteUpdated;
 
-    public Slider thisSlider;
+    [SerializeField]
+    [Tooltip("Reference to the AudioMixer to modify the parameter of.")]
+    AudioMixer mixer;
+    [SerializeField]
+    [Tooltip("The name of the audio mixer's parameter that this slider controls.")]
+    string mixerParameter;
+    [SerializeField]
+    [Tooltip("The slider to use for controlling the audio.")]
+    Slider slider;
+    [SerializeField]
+    [Tooltip("Whether the values (true value and non-muted value) of the slider should be saved.")]
+    bool saveValuesToDisk;
 
-    public Image btn;
+    // The last not-muted value that the slider was let go of at.
+    float lastNotMutedValue;
 
-    public bool music;
-    public bool sfx;
+    // The minimum amount of decibels that the slider can reach.
+    // This value should correspond to the audio being muted.
+    static float minimumDecibels = -80.0f;
 
     private void Start()
     {
         float value;
+        mixer.GetFloat(mixerParameter, out value);
+        slider.value = DecibelsToPercent(value);
 
-        if (music)
+        if (saveValuesToDisk)
         {
-            AudioController.Instance.sfxGroup.audioMixer.GetFloat("musicVol", out value);
-            if (value == -80f)
-            {
-                btn.color = Color.red;
-            }
-            else
-            {
-                btn.color = Color.white;
-            }
+            //lastNotMutedValue = DecibelsToPercent(PlayerPrefs.GetFloat(GetFullParameterNameNotMuted(), value));
+            lastNotMutedValue = PlayerPrefs.GetFloat(GetFullParameterNameNotMuted(), slider.value);
+        }
+        else
+        {
+            lastNotMutedValue = slider.value;
+        }
+        // If the volume is muted by default, lastNotMuted will be equal to muted volume.
+        // In this scenario, set lastNotMuted to maximum volume!
+        if (lastNotMutedValue == GetMuteVolume())
+        {
+            lastNotMutedValue = slider.maxValue;
         }
 
-        if (sfx)
+        // Update the mixer and event subscribers if necessary.
+        SliderChangeValue();
+    }
+
+    /*
+    private static float PercentToDecibels(float percent)
+    {
+        return 80 * (percent - 1.0f);
+    }
+    private static float DecibelsToPercent(float db)
+    {
+        return Mathf.Pow(10, db / 40.0f);
+    }
+    */
+    
+    private static float PercentToDecibels(float percent)
+    {
+        return Mathf.Max(minimumDecibels, 40.0f * Mathf.Log10(percent));
+    }
+    private static float DecibelsToPercent(float db)
+    {
+        if (db == minimumDecibels)
         {
-            AudioController.Instance.sfxGroup.audioMixer.GetFloat("sfxVol", out value);
-            if (value == -80f)
-            {
-                btn.color = Color.red;
-            }
-            else
-            {
-                btn.color = Color.white;
-            }
+            return 0.0f;
+        }
+        else
+        {
+            return Mathf.Pow(10, db / 40.0f);
         }
     }
 
-    public void ChangeMusicVol()
+    private string GetFullParameterName()
     {
-        AudioController.Instance.sfxGroup.audioMixer.SetFloat("musicVol", thisSlider.value);
-
-        float value;
-        AudioController.Instance.sfxGroup.audioMixer.GetFloat("musicVol", out value);
-        if (value == -80f)
-        { 
-            btn.color = Color.red;
-        }
-        else
-        {
-            btn.color = Color.white;
-        }
-
+        return GetFullParameterName(mixer.name, mixerParameter);
     }
 
-    public void ChangeSFXVol()
+    private static string GetFullParameterName(string mixerName, string parameterName)
     {
-        AudioController.Instance.sfxGroup.audioMixer.SetFloat("sfxVol", thisSlider.value);
-
-        float value;
-        AudioController.Instance.sfxGroup.audioMixer.GetFloat("sfxVol", out value);
-        if (value == -80f)
-        {
-            btn.color = Color.red;
-        }
-        else
-        {
-            btn.color = Color.white;
-        }
+        return mixerName + "." + parameterName;
     }
 
-    public void MuteMusic()
+    private string GetFullParameterNameNotMuted()
     {
-        float value;
-        AudioController.Instance.sfxGroup.audioMixer.GetFloat("musicVol", out value);
-        if (value == -80f)
+        return GetFullParameterName() + ".notMuted";
+    }
+
+    // Save the percent values of the slider.
+    private void SaveValues()
+    {
+        PlayerPrefs.SetFloat(GetFullParameterName(), slider.value);
+        PlayerPrefs.SetFloat(GetFullParameterNameNotMuted(), lastNotMutedValue);
+    }
+
+    private static void UpdateMixerValue(AudioMixer mixer, string parameterName, float percent)
+    {
+        float db = PercentToDecibels(percent);
+        mixer.SetFloat(parameterName, db);
+        //Debug.Log("AudioSlider.UpdateMixerValue: percent / db: " + percent + " / " + db);
+    }
+    
+    // Set the mixer parameter corresponding to this slider.
+    private void UpdateMixerValue()
+    {
+        UpdateMixerValue(mixer, mixerParameter, slider.value);
+    }
+
+    // Set the mixer parameter to the value that was saved.
+    // If the value was not saved, don't change the mixer parameter.
+    public static void LoadValueIntoMixer(AudioMixer mixer, string parameterName)
+    {
+        string key = GetFullParameterName(mixer.name, parameterName);
+        if (PlayerPrefs.HasKey(key))
         {
-            AudioController.Instance.sfxGroup.audioMixer.SetFloat("musicVol", 0);
-            thisSlider.value = 0;
-        }
-        else
-        {
-            AudioController.Instance.sfxGroup.audioMixer.SetFloat("musicVol", -80f);
-        }
-        
-        AudioController.Instance.sfxGroup.audioMixer.GetFloat("musicVol", out value);
-        if (value == -80f)
-        {
-            btn.color = Color.red;
-        }
-        else
-        {
-            btn.color = Color.white;
+            float value = PlayerPrefs.GetFloat(key);
+            UpdateMixerValue(mixer, parameterName, value);
         }
     }
 
-    public void MuteSFX()
+    // Get the value of the slider for muted volume.
+    private float GetMuteVolume()
     {
-        float value;
-        AudioController.Instance.sfxGroup.audioMixer.GetFloat("sfxVol", out value);
-        if (value == -80f)
-        {
-            AudioController.Instance.sfxGroup.audioMixer.SetFloat("sfxVol", 0);
-            thisSlider.value = 0;
-        }
-        else
-        {
-            AudioController.Instance.sfxGroup.audioMixer.SetFloat("sfxVol", -80f);
-        }
+        return slider.minValue;
+    }
 
-        AudioController.Instance.sfxGroup.audioMixer.GetFloat("sfxVol", out value);
-        if (value == -80f)
+    // Method that the Slider component should call each time its value changes.
+    public void SliderChangeValue()
+    {
+        UpdateMixerValue();
+        OnMuteUpdated();
+    }
+
+    // Toggles mute status on the slider.
+    public void ToggleMute()
+    {
+        float muteVolume = GetMuteVolume();
+        if (slider.value == muteVolume)
         {
-            btn.color = Color.red;
+            slider.value = lastNotMutedValue;
         }
         else
         {
-            btn.color = Color.white;
+            slider.value = muteVolume;
+        }
+        OnValueSettled();
+    }
+
+    // Called when the player lets go of the slider handle.
+    public void OnPointerUp(PointerEventData ped)
+    {
+        float muteVolume = GetMuteVolume();
+        if (slider.value != muteVolume)
+        {
+            lastNotMutedValue = slider.value;
+        }
+        OnValueSettled();
+    }
+
+    private void OnMuteUpdated()
+    {
+        if (MuteUpdated != null)
+        {
+            MuteUpdated(slider.value == GetMuteVolume());
+        }
+    }
+
+    // Called when the slider handle stops getting moved all over the place, settling on a value.
+    // In other words...
+    // Called when the user lets go of the slider or when the user calls ToggleMute.
+    private void OnValueSettled()
+    {
+        if (saveValuesToDisk)
+        {
+            SaveValues();
         }
     }
 }

--- a/Assets/Scripts/UI/MuteButton.cs
+++ b/Assets/Scripts/UI/MuteButton.cs
@@ -1,0 +1,27 @@
+﻿// Author(s): Paul Calande
+// A mute button class that subscribes to an AudioSlider.
+
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class MuteButton : MonoBehaviour
+{
+    [SerializeField]
+    [Tooltip("The audio slider to mute and unmute.")]
+    AudioSlider audioSlider;
+    [SerializeField]
+    [Tooltip("The crossed-out image over the mute button to enable and disable.")]
+    GameObject muteButtonCrossout;
+
+    // Use this for initialization
+    void Awake()
+    {
+        audioSlider.MuteUpdated += AudioSlider_MuteUpdated;
+    }
+
+    void AudioSlider_MuteUpdated(bool isMuted)
+    {
+        muteButtonCrossout.SetActive(isMuted);
+    }
+}

--- a/Assets/Scripts/UI/MuteButton.cs.meta
+++ b/Assets/Scripts/UI/MuteButton.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 6ca063964c2bf2d418091629e5f5cd8b
+timeCreated: 1510973784
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UI/SplashScreenMovie.cs
+++ b/Assets/Scripts/UI/SplashScreenMovie.cs
@@ -16,6 +16,12 @@ public class SplashScreenMovie : MonoBehaviour
     private void Start()
     {
         videoPlayer.loopPointReached += VideoFinished;
+        videoPlayer.prepareCompleted += VideoPrepared;
+        videoPlayer.Prepare();
+    }
+
+    private void VideoPrepared(VideoPlayer vp)
+    {
         videoPlayer.Play();
     }
 

--- a/Assets/Scripts/UI/UITitleMenus.cs
+++ b/Assets/Scripts/UI/UITitleMenus.cs
@@ -66,4 +66,9 @@ public class UITitleMenus : MonoBehaviour
 		SceneManager.LoadScene("GameMode");
 		AudioController.Instance.MenuClick();
 	}
+
+    public void PlayButtonSound()
+    {
+        AudioController.Instance.MenuClick();
+    }
 }

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -11,7 +11,7 @@ PlayerSettings:
   useOnDemandResources: 0
   accelerometerFrequency: 60
   companyName: HampshireCollegeCompSci
-  productName: Project I.O.N.A.
+  productName: Project IONA
   defaultCursor: {fileID: 0}
   cursorHotspot: {x: 0, y: 0}
   m_SplashScreenBackgroundColor: {r: 0.13725491, g: 0.12156863, b: 0.1254902, a: 1}


### PR DESCRIPTION
- Changed game title to Project IONA.
- Moved the energy counter to the top of the reactor.
- Implemented new art assets into settings menu: music symbol, SFX symbol, settings slider bar, and settings slider control node.
- Huge AudioSlider code overhaul.
- The game now saves the player's audio settings.
- The volume sliders now have a logarithmic progression, as any volume slider should.
- Potentially fixed the lag in the splash screen video by making the splash screen wait until it's fully prepared before it starts playing.